### PR TITLE
refactor: Extract search input into reusable component

### DIFF
--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -34,7 +34,7 @@ function SearchBar({
       <IconButton size="large" edge="start" aria-label="Go back" href="/">
         <ChevronLeft />
       </IconButton>
-      <SearchInput value={value} onChange={onChange} autoFocus />
+      <SearchInput value={value} onChangeAction={onChange} autoFocus />
     </Toolbar>
   );
 }

--- a/src/components/SearchInput/SearchInput.test.tsx
+++ b/src/components/SearchInput/SearchInput.test.tsx
@@ -4,48 +4,54 @@ import SearchInput from './index';
 
 describe('SearchInput', () => {
   it('renders with placeholder text', () => {
-    const onChange = vi.fn();
-    render(<SearchInput value="" onChange={onChange} placeholder="Search recipes…" />);
+    const onChangeAction = vi.fn();
+    render(
+      <SearchInput
+        value=""
+        onChangeAction={onChangeAction}
+        placeholder="Search recipes…"
+      />,
+    );
 
     const input = screen.getByRole('searchbox');
     expect(input).toHaveAttribute('placeholder', 'Search recipes…');
   });
 
   it('renders with default placeholder when not specified', () => {
-    const onChange = vi.fn();
-    render(<SearchInput value="" onChange={onChange} />);
+    const onChangeAction = vi.fn();
+    render(<SearchInput value="" onChangeAction={onChangeAction} />);
 
     const input = screen.getByRole('searchbox');
     expect(input).toHaveAttribute('placeholder', 'Search…');
   });
 
-  it('calls onChange when user types', async () => {
+  it('calls onChangeAction when user types', async () => {
     const user = userEvent.setup();
-    const onChange = vi.fn();
-    render(<SearchInput value="" onChange={onChange} />);
+    const onChangeAction = vi.fn();
+    render(<SearchInput value="" onChangeAction={onChangeAction} />);
 
     const input = screen.getByRole('searchbox');
     await user.type(input, 'margarita');
 
-    expect(onChange).toHaveBeenCalledTimes(9);
-    expect(onChange).toHaveBeenLastCalledWith('a');
+    expect(onChangeAction).toHaveBeenCalledTimes('margarita'.length);
+    expect(onChangeAction).toHaveBeenLastCalledWith('a');
   });
 
-  it('clears value and calls onChange with null when clear button clicked', async () => {
+  it('clears value and calls onChangeAction with null when clear button clicked', async () => {
     const user = userEvent.setup();
-    const onChange = vi.fn();
-    render(<SearchInput value="daiquiri" onChange={onChange} />);
+    const onChangeAction = vi.fn();
+    render(<SearchInput value="daiquiri" onChangeAction={onChangeAction} />);
 
     const clearButton = screen.getByRole('button', { name: /clear/i });
     await user.click(clearButton);
 
-    expect(onChange).toHaveBeenCalledWith(null);
+    expect(onChangeAction).toHaveBeenCalledWith(null);
   });
 
   it('focuses input after clearing', async () => {
     const user = userEvent.setup();
-    const onChange = vi.fn();
-    render(<SearchInput value="daiquiri" onChange={onChange} />);
+    const onChangeAction = vi.fn();
+    render(<SearchInput value="daiquiri" onChangeAction={onChangeAction} />);
 
     const input = screen.getByRole('searchbox');
     const clearButton = screen.getByRole('button', { name: /clear/i });
@@ -55,16 +61,16 @@ describe('SearchInput', () => {
   });
 
   it('auto-focuses when autoFocus prop is true', () => {
-    const onChange = vi.fn();
-    render(<SearchInput value="" onChange={onChange} autoFocus />);
+    const onChangeAction = vi.fn();
+    render(<SearchInput value="" onChangeAction={onChangeAction} autoFocus />);
 
     const input = screen.getByRole('searchbox');
     expect(input).toHaveFocus();
   });
 
   it('does not auto-focus when autoFocus prop is false', () => {
-    const onChange = vi.fn();
-    render(<SearchInput value="" onChange={onChange} autoFocus={false} />);
+    const onChangeAction = vi.fn();
+    render(<SearchInput value="" onChangeAction={onChangeAction} autoFocus={false} />);
 
     const input = screen.getByRole('searchbox');
     expect(input).not.toHaveFocus();
@@ -72,8 +78,8 @@ describe('SearchInput', () => {
 
   it('blurs input when Enter key is pressed', async () => {
     const user = userEvent.setup();
-    const onChange = vi.fn();
-    render(<SearchInput value="test" onChange={onChange} autoFocus />);
+    const onChangeAction = vi.fn();
+    render(<SearchInput value="test" onChangeAction={onChangeAction} autoFocus />);
 
     const input = screen.getByRole('searchbox');
     expect(input).toHaveFocus();
@@ -84,16 +90,16 @@ describe('SearchInput', () => {
   });
 
   it('displays the provided value', () => {
-    const onChange = vi.fn();
-    render(<SearchInput value="mojito" onChange={onChange} />);
+    const onChangeAction = vi.fn();
+    render(<SearchInput value="mojito" onChangeAction={onChangeAction} />);
 
     const input = screen.getByRole('searchbox');
     expect(input).toHaveValue('mojito');
   });
 
   it('has proper accessibility attributes', () => {
-    const onChange = vi.fn();
-    render(<SearchInput value="" onChange={onChange} />);
+    const onChangeAction = vi.fn();
+    render(<SearchInput value="" onChangeAction={onChangeAction} />);
 
     const input = screen.getByRole('searchbox');
     expect(input).toHaveAttribute('aria-label', 'search');

--- a/src/components/SearchInput/index.tsx
+++ b/src/components/SearchInput/index.tsx
@@ -37,19 +37,17 @@ const StyledInputBase = styled(InputBase)(({ theme }) => ({
   },
 }));
 
-type SearchInputProps = {
-  value: string;
-  onChange: (value: string | null) => void;
-  placeholder?: string;
-  autoFocus?: boolean;
-};
-
 export default function SearchInput({
   value,
-  onChange,
+  onChangeAction,
   placeholder = 'Search…',
   autoFocus = false,
-}: SearchInputProps) {
+}: {
+  value: string;
+  onChangeAction: (value: string | null) => void;
+  placeholder?: string;
+  autoFocus?: boolean;
+}) {
   const inputRef = useRef<HTMLInputElement>(null);
 
   return (
@@ -63,7 +61,7 @@ export default function SearchInput({
           placeholder={placeholder}
           inputProps={{ 'aria-label': 'search' }}
           value={value}
-          onChange={(e) => onChange(e.currentTarget.value)}
+          onChange={(e) => onChangeAction(e.currentTarget.value)}
           type="search"
           autoFocus={autoFocus}
           onKeyUp={(e) => {
@@ -76,7 +74,7 @@ export default function SearchInput({
       <Button
         type="reset"
         onClick={() => {
-          onChange(null);
+          onChangeAction(null);
           inputRef.current?.querySelector('input')?.focus();
         }}
       >


### PR DESCRIPTION
## Summary
- Extracts the styled search input UI from `SearchBar.tsx` into a new reusable `SearchInput` component
- New component supports `value`, `onChange`, `placeholder`, and `autoFocus` props
- Includes clear button functionality and Enter key blur (for mobile keyboard dismiss)
- Reduces SearchBar.tsx by ~70 lines

## Test plan
- [x] All existing tests pass
- [x] New SearchInput tests added covering:
  - Placeholder rendering
  - onChange callback on user input
  - Clear button resets value with `null`
  - Auto-focus behavior
  - Enter key blurs input
- [x] Manual: Navigate to `/search`, verify input is focused on load
- [x] Manual: Type text and verify input updates
- [x] Manual: Click Clear button and verify input is cleared and re-focused
- [x] Manual: Type text, press Enter, verify keyboard would dismiss (input blurs)