### PR TITLE
feat: add search text getter utilities

### DIFF
--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -3,7 +3,6 @@
 import { Recipe } from '@/types/Recipe';
 import { useMemo } from 'react';
 import { fuzzySearch } from '@/modules/fuzzySearch';
-import transliterate from '@sindresorhus/transliterate';
 import { getRecipeSearchText } from '@/modules/searchText';
 import {
   AppBar,

--- a/src/modules/searchText.test.ts
+++ b/src/modules/searchText.test.ts
@@ -54,7 +54,7 @@ function createMockRecipeIngredient(
 describe('getRecipeSearchText', () => {
   it('includes recipe name', () => {
     const recipe = createMockRecipe({ name: 'Daiquiri' });
-    expect(getRecipeSearchText(recipe)).toMatchInlineSnapshot(`"daiquiri  "`);
+    expect(getRecipeSearchText(recipe)).toMatchInlineSnapshot(`"daiquiri"`);
   });
 
   it('includes ingredient names', () => {
@@ -65,7 +65,7 @@ describe('getRecipeSearchText', () => {
       ],
     });
     expect(getRecipeSearchText(recipe)).toMatchInlineSnapshot(
-      `"test recipe white rum  lime juice  "`,
+      `"test recipe white rum  lime juice"`,
     );
   });
 
@@ -79,7 +79,7 @@ describe('getRecipeSearchText', () => {
       ],
     });
     expect(getRecipeSearchText(recipe)).toMatchInlineSnapshot(
-      `"test recipe appleton estate 8 year aged rum "`,
+      `"test recipe appleton estate 8 year aged rum"`,
     );
   });
 
@@ -97,12 +97,6 @@ describe('getRecipeSearchText', () => {
 
   it('transliterates special characters', () => {
     const recipe = createMockRecipe({ name: 'Café Cubano' });
-    expect(getRecipeSearchText(recipe)).toMatchInlineSnapshot(`"cafe cubano  "`);
-  });
-
-  it('returns lowercase text', () => {
-    const recipe = createMockRecipe({ name: 'MAI TAI' });
-    const result = getRecipeSearchText(recipe);
-    expect(result).toBe(result.toLowerCase());
+    expect(getRecipeSearchText(recipe)).toMatchInlineSnapshot(`"cafe cubano"`);
   });
 });

--- a/src/modules/searchText.ts
+++ b/src/modules/searchText.ts
@@ -8,7 +8,7 @@ import { type RecipeIngredient } from '@/types/Ingredient';
  * Returns transliterated lowercase text suitable for fuzzy search matching.
  */
 function normalize(text: string): string {
-  return transliterate(text).toLowerCase();
+  return transliterate(text).toLowerCase().trim();
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add reusable search text extraction functions for different entity types (recipes, ingredients, bars/authors)
- Refactor SearchBar to use the new `getRecipeSearchText` utility instead of inline logic
- Add comprehensive unit tests for all search text functions

## Test plan
- [x] Unit tests pass (`yarn vitest --run`)
- [x] Lint and typecheck pass (`yarn lint`)
- [x] Manual QA: Navigate to `/search` and verify search works as before
- [x] Manual QA: Search for ingredient names (e.g., "rum") to verify recipes appear
- [x] Manual QA: Search for bar/author names to verify recipes appear