### PR TITLE
feat: create SearchHeader, SearchAllLink and convert to /list/recipes (M5)

### DIFF
--- a/src/app/list/recipes/RecipesClient.test.tsx
+++ b/src/app/list/recipes/RecipesClient.test.tsx
@@ -1,8 +1,15 @@
 import { screen } from '@testing-library/react';
-import SearchPage from './SearchBar';
+import RecipesClient from './RecipesClient';
 import { Recipe } from '@/types/Recipe';
 import { getRecipeUrl } from '@/modules/url';
 import { renderWithNuqs, setupWithNuqs } from '@/testing';
+
+// Mock next/navigation
+const mockBack = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ back: mockBack }),
+  usePathname: () => '/list/recipes',
+}));
 
 let recipeCounter = 0;
 
@@ -33,15 +40,16 @@ const testRecipes: Recipe[] = [
   mockRecipe('The Last Word'),
 ];
 
-describe('SearchPage', () => {
+describe('RecipesClient', () => {
   beforeEach(() => {
     recipeCounter = 0;
+    mockBack.mockClear();
   });
 
-  it('renders search input and recipe list', () => {
-    renderWithNuqs(<SearchPage recipes={testRecipes} />);
+  it('renders title and recipe list when not searching', () => {
+    renderWithNuqs(<RecipesClient recipes={testRecipes} />);
 
-    expect(screen.getByRole('searchbox')).toBeInTheDocument();
+    expect(screen.getByText('All Recipes')).toBeInTheDocument();
 
     const mGroup = screen.getByRole('group', { name: 'M' });
     expect(mGroup).toHaveTextContent('Mojito');
@@ -50,8 +58,24 @@ describe('SearchPage', () => {
     expect(dGroup).toHaveTextContent('Daiquiri');
   });
 
-  it('typing in search filters the recipe list', async () => {
-    const { user } = setupWithNuqs(<SearchPage recipes={testRecipes} />);
+  it('clicking search icon activates search mode', async () => {
+    const { user } = setupWithNuqs(<RecipesClient recipes={testRecipes} />);
+
+    // Initially shows title
+    expect(screen.getByText('All Recipes')).toBeInTheDocument();
+
+    // Click search icon
+    await user.click(screen.getByRole('button', { name: /search/i }));
+
+    // Now shows search input
+    expect(screen.getByRole('searchbox')).toBeInTheDocument();
+    expect(screen.queryByText('All Recipes')).not.toBeInTheDocument();
+  });
+
+  it('typing filters recipe list', async () => {
+    const { user } = setupWithNuqs(<RecipesClient recipes={testRecipes} />, {
+      nuqsOptions: { searchParams: '?search=' },
+    });
 
     const input = screen.getByRole('searchbox');
     await user.type(input, 'moj');
@@ -62,80 +86,56 @@ describe('SearchPage', () => {
     expect(resultList).not.toHaveTextContent('Margarita');
   });
 
-  it('clearing search shows all recipes grouped by letter', async () => {
-    const { user } = setupWithNuqs(<SearchPage recipes={testRecipes} />, {
-      nuqsOptions: { searchParams: '?search=moj' },
-    });
-
-    // Initially filtered
-    const resultList = screen.getByRole('list');
-    expect(resultList).toHaveTextContent('Mojito');
-    expect(resultList).not.toHaveTextContent('Daiquiri');
-
-    // Clear the search
-    const clearButton = screen.getByRole('button', { name: /clear/i });
-    await user.click(clearButton);
-
-    // All recipes should be visible, grouped by letter
-    const mGroup = screen.getByRole('group', { name: 'M' });
-    expect(mGroup).toHaveTextContent('Mojito');
-    expect(mGroup).toHaveTextContent('Mai Tai');
-
-    const dGroup = screen.getByRole('group', { name: 'D' });
-    expect(dGroup).toHaveTextContent('Daiquiri');
-  });
-
   it('URL updates with search param when typing', async () => {
     const onUrlUpdate = vi.fn();
-    const { user } = setupWithNuqs(<SearchPage recipes={testRecipes} />, {
-      nuqsOptions: { onUrlUpdate },
+    const { user } = setupWithNuqs(<RecipesClient recipes={testRecipes} />, {
+      nuqsOptions: { searchParams: '?search=', onUrlUpdate },
     });
 
     const input = screen.getByRole('searchbox');
     await user.type(input, 'dai');
 
-    // Check that URL was updated with search param
     expect(onUrlUpdate).toHaveBeenLastCalledWith(
       expect.objectContaining({ queryString: '?search=dai' }),
     );
   });
 
   it('shows no results when search has no matches', async () => {
-    const { user } = setupWithNuqs(<SearchPage recipes={testRecipes} />);
+    const { user } = setupWithNuqs(<RecipesClient recipes={testRecipes} />, {
+      nuqsOptions: { searchParams: '?search=' },
+    });
 
     const input = screen.getByRole('searchbox');
     await user.type(input, 'xyznonexistent');
 
     expect(screen.getByText('No results found')).toBeInTheDocument();
-    expect(screen.getByText(/No recipes or ingredients matched/)).toBeInTheDocument();
+    expect(screen.getByText(/No recipes matched/)).toBeInTheDocument();
   });
 
   it('recipe items link to correct recipe detail pages', () => {
     const mojito = mockRecipe('Test Recipe');
-    renderWithNuqs(<SearchPage recipes={[mojito]} />);
+    renderWithNuqs(<RecipesClient recipes={[mojito]} />);
 
     const link = screen.getByRole('link', { name: /test recipe/i });
     expect(link).toHaveAttribute('href', getRecipeUrl(mojito));
   });
 
   it('loads with search term from URL', () => {
-    renderWithNuqs(<SearchPage recipes={testRecipes} />, {
+    renderWithNuqs(<RecipesClient recipes={testRecipes} />, {
       nuqsOptions: { searchParams: '?search=margarita' },
     });
 
     const input = screen.getByRole('searchbox');
     expect(input).toHaveValue('margarita');
 
-    // Select the result list and check its text content
     const resultList = screen.getByRole('list');
     expect(resultList).toHaveTextContent('Margarita');
     expect(resultList).not.toHaveTextContent('Mojito');
   });
 
   it('groups recipes by first letter when not searching', () => {
-    renderWithNuqs(<SearchPage recipes={testRecipes} />);
+    renderWithNuqs(<RecipesClient recipes={testRecipes} />);
 
-    // Groups are identified by aria-labelledby pointing to their header
     const dGroup = screen.getByRole('group', { name: 'D' });
     const lGroup = screen.getByRole('group', { name: 'L' });
     const mGroup = screen.getByRole('group', { name: 'M' });
@@ -145,5 +145,14 @@ describe('SearchPage', () => {
     expect(mGroup).toHaveTextContent('Mojito');
     expect(mGroup).toHaveTextContent('Margarita');
     expect(mGroup).toHaveTextContent('Mai Tai');
+  });
+
+  it('back button navigates correctly', async () => {
+    const { user } = setupWithNuqs(<RecipesClient recipes={testRecipes} />);
+
+    const backButton = screen.getByRole('button', { name: /go back/i });
+    await user.click(backButton);
+
+    expect(mockBack).toHaveBeenCalled();
   });
 });

--- a/src/app/list/recipes/RecipesClient.tsx
+++ b/src/app/list/recipes/RecipesClient.tsx
@@ -3,43 +3,16 @@
 import { Recipe } from '@/types/Recipe';
 import { useMemo } from 'react';
 import { getRecipeSearchText } from '@/modules/searchText';
-import {
-  AppBar,
-  Card,
-  CardContent,
-  CardHeader,
-  IconButton,
-  Toolbar,
-  Typography,
-} from '@mui/material';
-import ChevronLeft from '@mui/icons-material/ChevronLeft';
+import { Card, CardContent, CardHeader, Typography } from '@mui/material';
 import { useQueryState } from 'nuqs';
 import RecipeList from '@/components/RecipeList';
-import SearchInput from '@/components/SearchInput';
 import SearchableList from '@/components/SearchableList';
+import SearchHeader from '@/components/SearchHeader';
 
-function SearchBar({
-  value,
-  onChange,
-}: {
-  value: string;
-  onChange: (value: string | null) => void;
-}) {
-  return (
-    <Toolbar>
-      <IconButton size="large" edge="start" aria-label="Go back" href="/">
-        <ChevronLeft />
-      </IconButton>
-      <SearchInput value={value} onChangeAction={onChange} autoFocus />
-    </Toolbar>
-  );
-}
-
-export default function SearchPage({ recipes }: { recipes: Recipe[] }) {
+export default function RecipesClient({ recipes }: { recipes: Recipe[] }) {
   const [searchTerm, setSearchTerm] = useQueryState('search');
 
   const nameIsUnique = useMemo(() => {
-    // Normalize names to lower case to avoid case sensitivity
     const store = Object.groupBy(recipes, (recipe) => recipe.name.toLowerCase());
     return (name: string) => store[name.toLowerCase()]?.length === 1;
   }, [recipes]);
@@ -49,7 +22,7 @@ export default function SearchPage({ recipes }: { recipes: Recipe[] }) {
       <CardHeader title="No results found" />
       <CardContent>
         <Typography variant="body2">
-          No recipes or ingredients matched the search term &quot;{searchTerm}&quot;
+          No recipes matched the search term &quot;{searchTerm}&quot;
         </Typography>
       </CardContent>
     </Card>
@@ -57,10 +30,11 @@ export default function SearchPage({ recipes }: { recipes: Recipe[] }) {
 
   return (
     <>
-      <AppBar>
-        <SearchBar onChange={setSearchTerm} value={searchTerm ?? ''} />
-      </AppBar>
-      <Toolbar />
+      <SearchHeader
+        title="All Recipes"
+        searchTerm={searchTerm}
+        onSearchChange={setSearchTerm}
+      />
       <SearchableList
         items={recipes}
         getSearchText={getRecipeSearchText}

--- a/src/app/list/recipes/page.tsx
+++ b/src/app/list/recipes/page.tsx
@@ -1,0 +1,18 @@
+import { Metadata } from 'next';
+import RecipesClient from './RecipesClient';
+import { Suspense } from 'react';
+import { getAllRecipes } from '@/modules/recipes';
+
+export const metadata: Metadata = {
+  title: 'Cocktail Index | All Recipes',
+};
+
+export default async function RecipesPage() {
+  const recipes = await getAllRecipes();
+
+  return (
+    <Suspense>
+      <RecipesClient recipes={recipes} />
+    </Suspense>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,7 +24,7 @@ import {
   getBarListUrl,
   getBottleListUrl,
   getIngredientListUrl,
-  getSearchUrl,
+  getRecipeListUrl,
   getSourceUrl,
 } from '@/modules/url';
 import { getAllSources } from '@/modules/sources';
@@ -68,7 +68,7 @@ export default async function HomePage() {
       <AppHeader title="Cocktail Index" />
       <List sx={{ mt: 2 }}>
         <Paper square>
-          <Link href={getSearchUrl()}>
+          <Link href={getRecipeListUrl()}>
             <ListItem disablePadding divider secondaryAction={<ChevronRightIcon />}>
               <ListItemButton>
                 <ListItemIcon>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,20 +1,15 @@
-import { Metadata } from 'next';
-import Search from './SearchBar';
-import { Suspense } from 'react';
-import { getAllRecipes } from '@/modules/recipes';
+import { redirect } from 'next/navigation';
 
-export const metadata: Metadata = {
-  title: 'Cocktail Index | Search',
-};
-
-export default async function SearchPage() {
-  const recipes = await getAllRecipes();
-
-  return (
-    <>
-      <Suspense>
-        <Search recipes={recipes} />
-      </Suspense>
-    </>
-  );
+export default function SearchPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ search?: string }>;
+}) {
+  // Redirect to /list/recipes, preserving search param if present
+  return searchParams.then((params) => {
+    const url = params.search
+      ? `/list/recipes?search=${encodeURIComponent(params.search)}`
+      : '/list/recipes';
+    redirect(url);
+  });
 }

--- a/src/components/AppHeader/index.tsx
+++ b/src/components/AppHeader/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { getSearchUrl } from '@/modules/url';
+import { getRecipeListUrl } from '@/modules/url';
 import { ChevronLeft, Search } from '@mui/icons-material';
 import { AppBar, Icon, IconButton, Toolbar, Typography } from '@mui/material';
 import { useRouter, usePathname } from 'next/navigation';
@@ -37,7 +37,12 @@ export default function AppHeader({ title }: { title: string }) {
           >
             {title}
           </Typography>
-          <IconButton size="large" edge="end" aria-label="Search" href={getSearchUrl()}>
+          <IconButton
+            size="large"
+            edge="end"
+            aria-label="Search"
+            href={getRecipeListUrl()}
+          >
             <Search />
           </IconButton>
         </Toolbar>

--- a/src/components/SearchAllLink/SearchAllLink.test.tsx
+++ b/src/components/SearchAllLink/SearchAllLink.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import SearchAllLink from './index';
+
+describe('SearchAllLink', () => {
+  it('renders link with correct href including encoded search term', () => {
+    render(<SearchAllLink searchTerm="mai tai" />);
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/list/recipes?search=mai+tai');
+  });
+
+  it('handles special characters in search term', () => {
+    render(<SearchAllLink searchTerm="rum & coke" />);
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/list/recipes?search=rum+%26+coke');
+  });
+
+  it('does not render when searchTerm is null', () => {
+    const { container } = render(<SearchAllLink searchTerm={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not render when searchTerm is empty string', () => {
+    const { container } = render(<SearchAllLink searchTerm="" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not render when searchTerm is whitespace only', () => {
+    const { container } = render(<SearchAllLink searchTerm="   " />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('displays helpful text for users', () => {
+    render(<SearchAllLink searchTerm="test" />);
+
+    expect(screen.getByText(/not finding what you're looking for/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/SearchAllLink/index.tsx
+++ b/src/components/SearchAllLink/index.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link';
+import { Card, CardContent, Typography } from '@mui/material';
+import { ChevronRight } from '@mui/icons-material';
+
+export default function SearchAllLink({ searchTerm }: { searchTerm: string | null }) {
+  if (!searchTerm || searchTerm.trim() === '') {
+    return null;
+  }
+
+  const searchParams = new URLSearchParams({ search: searchTerm });
+
+  return (
+    <Card sx={{ m: 2 }}>
+      <CardContent>
+        <Link href={`/list/recipes?${searchParams.toString()}`}>
+          <Typography
+            variant="body2"
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+            }}
+          >
+            Not finding what you&apos;re looking for? Search all recipes
+            <ChevronRight />
+          </Typography>
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/SearchHeader/SearchHeader.test.tsx
+++ b/src/components/SearchHeader/SearchHeader.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SearchHeader from './index';
+
+// Mock next/navigation
+const mockBack = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ back: mockBack }),
+  usePathname: () => '/list/recipes',
+}));
+
+describe('SearchHeader', () => {
+  beforeEach(() => {
+    mockBack.mockClear();
+  });
+
+  it('renders title when search is not active', () => {
+    render(
+      <SearchHeader title="All Recipes" searchTerm={null} onSearchChange={vi.fn()} />,
+    );
+
+    expect(screen.getByText('All Recipes')).toBeInTheDocument();
+    expect(screen.queryByRole('searchbox')).not.toBeInTheDocument();
+  });
+
+  it('shows search input when search icon clicked', async () => {
+    const user = userEvent.setup();
+    const onSearchChange = vi.fn();
+
+    render(
+      <SearchHeader
+        title="All Recipes"
+        searchTerm={null}
+        onSearchChange={onSearchChange}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /search/i }));
+
+    expect(onSearchChange).toHaveBeenCalledWith('');
+  });
+
+  it('shows search input when searchTerm is provided', () => {
+    render(
+      <SearchHeader title="All Recipes" searchTerm="mojito" onSearchChange={vi.fn()} />,
+    );
+
+    expect(screen.getByRole('searchbox')).toBeInTheDocument();
+    expect(screen.getByRole('searchbox')).toHaveValue('mojito');
+    expect(screen.queryByText('All Recipes')).not.toBeInTheDocument();
+  });
+
+  it('calls onSearchChange when typing in search input', async () => {
+    const user = userEvent.setup();
+    const onSearchChange = vi.fn();
+
+    render(
+      <SearchHeader title="All Recipes" searchTerm="" onSearchChange={onSearchChange} />,
+    );
+
+    const input = screen.getByRole('searchbox');
+    await user.type(input, 'dai');
+
+    expect(onSearchChange).toHaveBeenCalledTimes('dai'.length);
+  });
+
+  it('back button is always visible and clickable', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SearchHeader title="All Recipes" searchTerm={null} onSearchChange={vi.fn()} />,
+    );
+
+    const backButton = screen.getByRole('button', { name: /go back/i });
+    expect(backButton).toBeInTheDocument();
+
+    await user.click(backButton);
+    expect(mockBack).toHaveBeenCalled();
+  });
+
+  it('close button clears search and returns to title view', async () => {
+    const user = userEvent.setup();
+    const onSearchChange = vi.fn();
+
+    render(
+      <SearchHeader
+        title="All Recipes"
+        searchTerm="mojito"
+        onSearchChange={onSearchChange}
+      />,
+    );
+
+    const closeButton = screen.getByRole('button', { name: /close search/i });
+    await user.click(closeButton);
+
+    expect(onSearchChange).toHaveBeenCalledWith(null);
+  });
+
+  it('search toggle button has correct aria-label', () => {
+    render(
+      <SearchHeader title="All Recipes" searchTerm={null} onSearchChange={vi.fn()} />,
+    );
+
+    expect(screen.getByRole('button', { name: /search/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/SearchHeader/index.tsx
+++ b/src/components/SearchHeader/index.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { ChevronLeft, Search, Close } from '@mui/icons-material';
+import { AppBar, IconButton, Toolbar, Typography } from '@mui/material';
+import { useRouter, usePathname } from 'next/navigation';
+import SearchInput from '@/components/SearchInput';
+
+export default function SearchHeader({
+  title,
+  searchTerm,
+  onSearchChange,
+}: {
+  title: string;
+  searchTerm: string | null;
+  onSearchChange: (value: string | null) => void;
+}) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const isHome = pathname === '/';
+  const isSearchActive = searchTerm !== null;
+
+  return (
+    <>
+      <AppBar>
+        <Toolbar>
+          {isHome ? (
+            <IconButton size="large" edge="start" disabled>
+              <ChevronLeft sx={{ visibility: 'hidden' }} />
+            </IconButton>
+          ) : (
+            <IconButton
+              size="large"
+              edge="start"
+              aria-label="Go back"
+              onClick={() => router.back()}
+            >
+              <ChevronLeft />
+            </IconButton>
+          )}
+
+          {isSearchActive ? (
+            <SearchInput value={searchTerm} onChangeAction={onSearchChange} autoFocus />
+          ) : (
+            <Typography
+              variant="h6"
+              noWrap
+              component="div"
+              textAlign="center"
+              sx={{ flexGrow: 1, flexShrink: 1 }}
+            >
+              {title}
+            </Typography>
+          )}
+
+          {isSearchActive ? (
+            <IconButton
+              size="large"
+              edge="end"
+              aria-label="Close search"
+              onClick={() => onSearchChange(null)}
+            >
+              <Close />
+            </IconButton>
+          ) : (
+            <IconButton
+              size="large"
+              edge="end"
+              aria-label="Search"
+              onClick={() => onSearchChange('')}
+            >
+              <Search />
+            </IconButton>
+          )}
+        </Toolbar>
+      </AppBar>
+      <Toolbar />
+    </>
+  );
+}

--- a/src/modules/url.ts
+++ b/src/modules/url.ts
@@ -21,8 +21,8 @@ export function getSourceUrl(source: Source) {
   return `/source/${source.type}/${source.slug}`;
 }
 
-export function getSearchUrl() {
-  return `/search`;
+export function getRecipeListUrl() {
+  return '/list/recipes';
 }
 
 export function getBottleListUrl() {


### PR DESCRIPTION
## Summary
- Add `SearchHeader` component that toggles between title and search input
- Add `SearchAllLink` component for "search all recipes" link (to be used in other list pages)
- Create `/list/recipes` page with `RecipesClient` using `SearchableList`
- Add redirect from `/search` to `/list/recipes` for backwards compatibility
- Rename `getSearchUrl` to `getRecipeListUrl` in url module

## Test plan
- [x] All 159 tests pass
- [x] Manual test: Navigate to /list/recipes shows all recipes grouped alphabetically
- [x] Manual test: Click search icon toggles to search input
- [x] Manual test: Type in search filters recipes in real-time
- [x] Manual test: Close button returns to title view
- [x] Manual test: /search redirects to /list/recipes
- [x] Manual test: /search?search=mojito redirects to /list/recipes?search=mojito