### PR TITLE
fix: wrap search page useSearchParams in Suspense boundary

### DIFF
--- a/src/app/search/SearchRedirect.tsx
+++ b/src/app/search/SearchRedirect.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useSearchParams, useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+export default function SearchRedirect() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const search = searchParams.get('search');
+    const url = search
+      ? `/list/recipes?search=${encodeURIComponent(search)}`
+      : '/list/recipes';
+    router.replace(url);
+  }, [router, searchParams]);
+
+  return null;
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,19 +1,10 @@
-'use client';
-
-import { useSearchParams, useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import { Suspense } from 'react';
+import SearchRedirect from './SearchRedirect';
 
 export default function SearchPage() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
-  useEffect(() => {
-    const search = searchParams.get('search');
-    const url = search
-      ? `/list/recipes?search=${encodeURIComponent(search)}`
-      : '/list/recipes';
-    router.replace(url);
-  }, [router, searchParams]);
-
-  return null;
+  return (
+    <Suspense fallback={null}>
+      <SearchRedirect />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
## Summary
- Fixes build failure on main branch caused by `useSearchParams()` not being wrapped in Suspense
- Split search page into server component (`page.tsx`) wrapping a client component (`SearchRedirect.tsx`)
- Next.js requires useSearchParams() to be wrapped in a Suspense boundary at the page level for static rendering

## Test plan
- [x] Verified build passes with `yarn build`