### PR TITLE
feat: add SearchHeader component and update RecipesClient

### DIFF
--- a/src/app/list/recipes/RecipesClient.tsx
+++ b/src/app/list/recipes/RecipesClient.tsx
@@ -3,51 +3,16 @@
 import { Recipe } from '@/types/Recipe';
 import { useMemo } from 'react';
 import { getRecipeSearchText } from '@/modules/searchText';
-import {
-  AppBar,
-  Card,
-  CardContent,
-  CardHeader,
-  IconButton,
-  Toolbar,
-  Typography,
-} from '@mui/material';
-import ChevronLeft from '@mui/icons-material/ChevronLeft';
+import { Card, CardContent, CardHeader, Typography } from '@mui/material';
 import { useQueryState } from 'nuqs';
 import RecipeList from '@/components/RecipeList';
-import SearchInput from '@/components/SearchInput';
 import SearchableList from '@/components/SearchableList';
-import { useRouter } from 'next/router';
-
-function SearchBar({
-  value,
-  onChange,
-}: {
-  value: string;
-  onChange: (value: string | null) => void;
-}) {
-  const router = useRouter();
-
-  return (
-    <Toolbar>
-      <IconButton
-        size="large"
-        edge="start"
-        aria-label="Go back"
-        onClick={() => router.back()}
-      >
-        <ChevronLeft />
-      </IconButton>
-      <SearchInput value={value} onChangeAction={onChange} autoFocus />
-    </Toolbar>
-  );
-}
+import SearchHeader from '@/components/SearchHeader';
 
 export default function RecipesClient({ recipes }: { recipes: Recipe[] }) {
   const [searchTerm, setSearchTerm] = useQueryState('search');
 
   const nameIsUnique = useMemo(() => {
-    // Normalize names to lower case to avoid case sensitivity
     const store = Object.groupBy(recipes, (recipe) => recipe.name.toLowerCase());
     return (name: string) => store[name.toLowerCase()]?.length === 1;
   }, [recipes]);
@@ -65,10 +30,11 @@ export default function RecipesClient({ recipes }: { recipes: Recipe[] }) {
 
   return (
     <>
-      <AppBar>
-        <SearchBar onChange={setSearchTerm} value={searchTerm ?? ''} />
-      </AppBar>
-      <Toolbar />
+      <SearchHeader
+        title="All Recipes"
+        searchTerm={searchTerm}
+        onSearchChange={setSearchTerm}
+      />
       <SearchableList
         items={recipes}
         getSearchText={getRecipeSearchText}

--- a/src/components/SearchHeader/SearchHeader.test.tsx
+++ b/src/components/SearchHeader/SearchHeader.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SearchHeader from './index';
+
+// Mock next/navigation
+const mockBack = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ back: mockBack }),
+  usePathname: () => '/list/recipes',
+}));
+
+describe('SearchHeader', () => {
+  beforeEach(() => {
+    mockBack.mockClear();
+  });
+
+  it('renders title when search is not active', () => {
+    render(
+      <SearchHeader title="All Recipes" searchTerm={null} onSearchChange={vi.fn()} />,
+    );
+
+    expect(screen.getByText('All Recipes')).toBeInTheDocument();
+    expect(screen.queryByRole('searchbox')).not.toBeInTheDocument();
+  });
+
+  it('shows search input when search icon clicked', async () => {
+    const user = userEvent.setup();
+    const onSearchChange = vi.fn();
+
+    render(
+      <SearchHeader
+        title="All Recipes"
+        searchTerm={null}
+        onSearchChange={onSearchChange}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /search/i }));
+
+    expect(onSearchChange).toHaveBeenCalledWith('');
+  });
+
+  it('shows search input when searchTerm is provided', () => {
+    render(
+      <SearchHeader title="All Recipes" searchTerm="mojito" onSearchChange={vi.fn()} />,
+    );
+
+    expect(screen.getByRole('searchbox')).toBeInTheDocument();
+    expect(screen.getByRole('searchbox')).toHaveValue('mojito');
+    expect(screen.queryByText('All Recipes')).not.toBeInTheDocument();
+  });
+
+  it('calls onSearchChange when typing in search input', async () => {
+    const user = userEvent.setup();
+    const onSearchChange = vi.fn();
+
+    render(
+      <SearchHeader title="All Recipes" searchTerm="" onSearchChange={onSearchChange} />,
+    );
+
+    const input = screen.getByRole('searchbox');
+    await user.type(input, 'dai');
+
+    expect(onSearchChange).toHaveBeenCalledTimes('dai'.length);
+  });
+
+  it('back button is always visible and clickable', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SearchHeader title="All Recipes" searchTerm={null} onSearchChange={vi.fn()} />,
+    );
+
+    const backButton = screen.getByRole('button', { name: /go back/i });
+    expect(backButton).toBeInTheDocument();
+
+    await user.click(backButton);
+    expect(mockBack).toHaveBeenCalled();
+  });
+
+  it('close button clears search and returns to title view', async () => {
+    const user = userEvent.setup();
+    const onSearchChange = vi.fn();
+
+    render(
+      <SearchHeader
+        title="All Recipes"
+        searchTerm="mojito"
+        onSearchChange={onSearchChange}
+      />,
+    );
+
+    const closeButton = screen.getByRole('button', { name: /close search/i });
+    await user.click(closeButton);
+
+    expect(onSearchChange).toHaveBeenCalledWith(null);
+  });
+
+  it('search toggle button has correct aria-label', () => {
+    render(
+      <SearchHeader title="All Recipes" searchTerm={null} onSearchChange={vi.fn()} />,
+    );
+
+    expect(screen.getByRole('button', { name: /search/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/SearchHeader/index.tsx
+++ b/src/components/SearchHeader/index.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { ChevronLeft, Search, Close } from '@mui/icons-material';
+import { AppBar, IconButton, Toolbar, Typography } from '@mui/material';
+import { useRouter, usePathname } from 'next/navigation';
+import SearchInput from '@/components/SearchInput';
+
+export default function SearchHeader({
+  title,
+  searchTerm,
+  onSearchChange,
+}: {
+  title: string;
+  searchTerm: string | null;
+  onSearchChange: (value: string | null) => void;
+}) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const isHome = pathname === '/';
+  const isSearchActive = searchTerm !== null;
+
+  return (
+    <>
+      <AppBar>
+        <Toolbar>
+          {isHome ? (
+            <IconButton size="large" edge="start" disabled>
+              <ChevronLeft sx={{ visibility: 'hidden' }} />
+            </IconButton>
+          ) : (
+            <IconButton
+              size="large"
+              edge="start"
+              aria-label="Go back"
+              onClick={() => router.back()}
+            >
+              <ChevronLeft />
+            </IconButton>
+          )}
+
+          {isSearchActive ? (
+            <SearchInput value={searchTerm} onChangeAction={onSearchChange} autoFocus />
+          ) : (
+            <Typography
+              variant="h6"
+              noWrap
+              component="div"
+              textAlign="center"
+              sx={{ flexGrow: 1, flexShrink: 1 }}
+            >
+              {title}
+            </Typography>
+          )}
+
+          {isSearchActive ? (
+            <IconButton
+              size="large"
+              edge="end"
+              aria-label="Close search"
+              onClick={() => onSearchChange(null)}
+            >
+              <Close />
+            </IconButton>
+          ) : (
+            <IconButton
+              size="large"
+              edge="end"
+              aria-label="Search"
+              onClick={() => onSearchChange('')}
+            >
+              <Search />
+            </IconButton>
+          )}
+        </Toolbar>
+      </AppBar>
+      <Toolbar />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

- Add reusable SearchHeader component that integrates AppHeader functionality with search capabilities
- Refactor RecipesClient to use the new SearchHeader component, simplifying the recipes page
- Include comprehensive tests for SearchHeader component

## Test plan

- [x] All existing tests pass
- [x] New SearchHeader tests pass
- [ ] Manual test: verify search toggle works on recipes page
- [ ] Manual test: verify back navigation works correctly