### PR TITLE
chore(lint): enable consistent-type-imports eslint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,11 @@ const eslintConfig = [
   {
     ignores: ['node_modules/**', '.next/**', 'out/**', 'build/**', 'next-env.d.ts'],
   },
+  {
+    rules: {
+      '@typescript-eslint/consistent-type-imports': 'error',
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/src/app/calculators/acid-adjusting/page.tsx
+++ b/src/app/calculators/acid-adjusting/page.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import AppHeader from '@/components/AppHeader';
 import { Suspense } from 'react';
 import AcidAdjustingCalculator from '@/components/AcidAdjustingCalculator';

--- a/src/app/calculators/page.tsx
+++ b/src/app/calculators/page.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import AppHeader from '@/components/AppHeader';
 import { Suspense } from 'react';
 import { List, ListItem, ListItemText, Paper } from '@mui/material';

--- a/src/app/list/authors/[name]/page.tsx
+++ b/src/app/list/authors/[name]/page.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import AppHeader from '@/components/AppHeader';
 import { Suspense } from 'react';
@@ -8,7 +8,7 @@ import { getRecipeUrl } from '@/modules/url';
 import { ChevronRight } from '@mui/icons-material';
 import { notFound } from 'next/navigation';
 import slugify from '@sindresorhus/slugify';
-import { Recipe } from '@/types/Recipe';
+import type { Recipe } from '@/types/Recipe';
 
 // Helper function to find the actual author name from the slug
 function findAuthorNameFromSlug(slug: string, recipes: Recipe[]): string | null {

--- a/src/app/list/authors/page.tsx
+++ b/src/app/list/authors/page.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import AppHeader from '@/components/AppHeader';
 import { Suspense } from 'react';

--- a/src/app/list/bars/[name]/page.tsx
+++ b/src/app/list/bars/[name]/page.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import AppHeader from '@/components/AppHeader';
 import { Suspense } from 'react';
@@ -8,7 +8,7 @@ import { getRecipeUrl } from '@/modules/url';
 import { ChevronRight } from '@mui/icons-material';
 import { notFound } from 'next/navigation';
 import slugify from '@sindresorhus/slugify';
-import { Recipe } from '@/types/Recipe';
+import type { Recipe } from '@/types/Recipe';
 
 // Helper function to find the actual bar name from the slug
 function findBarNameFromSlug(

--- a/src/app/list/bars/page.tsx
+++ b/src/app/list/bars/page.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import AppHeader from '@/components/AppHeader';
 import { Suspense } from 'react';

--- a/src/app/list/bottles/page.tsx
+++ b/src/app/list/bottles/page.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import AppHeader from '@/components/AppHeader';
 import { Suspense } from 'react';

--- a/src/app/list/ingredients/page.tsx
+++ b/src/app/list/ingredients/page.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import AppHeader from '@/components/AppHeader';
 import { Suspense } from 'react';

--- a/src/app/list/recipes/RecipesClient.tsx
+++ b/src/app/list/recipes/RecipesClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Recipe } from '@/types/Recipe';
+import type { Recipe } from '@/types/Recipe';
 import { useMemo } from 'react';
 import { getRecipeSearchText } from '@/modules/searchText';
 import {

--- a/src/app/list/recipes/page.tsx
+++ b/src/app/list/recipes/page.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import RecipesClient from './RecipesClient';
 import { Suspense } from 'react';
 import { getAllRecipes } from '@/modules/recipes';

--- a/src/app/manifest.webmanifest/route.ts
+++ b/src/app/manifest.webmanifest/route.ts
@@ -1,4 +1,4 @@
-import { MetadataRoute } from 'next';
+import type { MetadataRoute } from 'next';
 
 export const dynamic = 'force-static';
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import AppHeader from '@/components/AppHeader';
 import { Suspense } from 'react';
 import {
@@ -28,7 +28,7 @@ import {
   getSourceUrl,
 } from '@/modules/url';
 import { getAllSources } from '@/modules/sources';
-import { Source } from '@/types/Source';
+import type { Source } from '@/types/Source';
 
 export const metadata: Metadata = {
   title: 'Cocktail Index',

--- a/src/app/recipes/[type]/[source]/[recipe]/page.tsx
+++ b/src/app/recipes/[type]/[source]/[recipe]/page.tsx
@@ -3,7 +3,7 @@ import AppHeader from '@/components/AppHeader';
 import { getRecipe } from '@/modules/recipes';
 import { getRecipePageParams } from '@/modules/params';
 import { Box } from '@mui/material';
-import { Source } from '@/types/Source';
+import type { Source } from '@/types/Source';
 import styles from './style.module.css';
 import { Grid2, List, ListItem, ListItemText, ListSubheader, Paper } from '@mui/material';
 import IngredientList from '@/components/IngredientList';

--- a/src/app/source/[type]/[name]/page.tsx
+++ b/src/app/source/[type]/[name]/page.tsx
@@ -9,7 +9,7 @@ import { getSource } from '@/modules/sources';
 import { getSourcePageParams } from '@/modules/params';
 import { getRecipesFromSource } from '@/modules/recipes';
 import SourceAboutCard from '@/components/SourceAboutCard';
-import { Source } from '@/types/Source';
+import type { Source } from '@/types/Source';
 
 type Params = { type: Source['type']; name: string };
 

--- a/src/app/theme.tsx
+++ b/src/app/theme.tsx
@@ -1,7 +1,9 @@
 'use client';
 import { createTheme } from '@mui/material/styles';
-import NextLink, { LinkProps } from 'next/link';
-import { forwardRef, Ref } from 'react';
+import type { LinkProps } from 'next/link';
+import NextLink from 'next/link';
+import type { Ref } from 'react';
+import { forwardRef } from 'react';
 
 const LinkBehaviour = forwardRef(function LinkBehaviour(
   props: LinkProps,

--- a/src/components/AcidAdjustingCalculator/index.tsx
+++ b/src/components/AcidAdjustingCalculator/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { SxProps } from '@mui/material';
 import {
   Button,
   Card,
@@ -7,7 +8,6 @@ import {
   CardHeader,
   InputAdornment,
   Stack,
-  SxProps,
   TextField,
   ToggleButton,
   ToggleButtonGroup,

--- a/src/components/BrixCalculator/index.tsx
+++ b/src/components/BrixCalculator/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { SxProps } from '@mui/material';
 import {
   Button,
   Card,
@@ -7,7 +8,6 @@ import {
   CardHeader,
   InputAdornment,
   Stack,
-  SxProps,
   TextField,
   Typography,
 } from '@mui/material';

--- a/src/components/CategoryName/index.tsx
+++ b/src/components/CategoryName/index.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import LocalOfferIcon from '@mui/icons-material/LocalOffer';
-import { Category } from '@/types/Category';
+import type { Category } from '@/types/Category';
 import { getCategoryUrl } from '@/modules/url';
 import styles from './category.module.css';
 

--- a/src/components/FixBugCard/index.tsx
+++ b/src/components/FixBugCard/index.tsx
@@ -1,4 +1,5 @@
-import { Button, Card, CardContent, Stack, SxProps } from '@mui/material';
+import type { SxProps } from '@mui/material';
+import { Button, Card, CardContent, Stack } from '@mui/material';
 import BugReportIcon from '@mui/icons-material/BugReport';
 
 export default function FixBugCard({ fixUrl, sx }: { fixUrl: string; sx?: SxProps }) {

--- a/src/components/IngredientList/IngredientList.test.tsx
+++ b/src/components/IngredientList/IngredientList.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import IngredientList from './index';
-import { Recipe } from '@/types/Recipe';
+import type { Recipe } from '@/types/Recipe';
 
 describe('IngredientList', () => {
   const mockIngredients: Recipe['ingredients'] = [

--- a/src/components/IngredientList/index.tsx
+++ b/src/components/IngredientList/index.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import sortIngredients from './sortIngredients';
 import styles from './style.module.css';
 import Quantity from '@/components/Quantity';
-import { Recipe } from '@/types/Recipe';
+import type { Recipe } from '@/types/Recipe';
 import UnitSelector, { type Unit } from '@/components/Quantity/Selector';
 import ServingSelector from '@/components/ServingSelector';
 import useLocalStorage from '@/hooks/useLocalStorage';

--- a/src/components/IngredientList/sortIngredients.ts
+++ b/src/components/IngredientList/sortIngredients.ts
@@ -1,5 +1,5 @@
 import { convertQuantityToMl } from '@/modules/conversion';
-import { RecipeIngredient } from '@/types/Ingredient';
+import type { RecipeIngredient } from '@/types/Ingredient';
 
 const UNIT_PRIORITIES: Record<RecipeIngredient['quantity']['unit'], number> = {
   spray: 0,

--- a/src/components/Quantity/index.tsx
+++ b/src/components/Quantity/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import styles from './style.module.css';
-import { RecipeIngredient } from '@/types/Ingredient';
+import type { RecipeIngredient } from '@/types/Ingredient';
 import { convertQuantityToMl, convertQuantityToOz } from '@/modules/conversion';
 import { Stack } from '@mui/material';
 import { match } from 'ts-pattern';

--- a/src/components/RecipeAttributionCard/index.tsx
+++ b/src/components/RecipeAttributionCard/index.tsx
@@ -1,16 +1,16 @@
+import type { SxProps } from '@mui/material';
 import {
   Card,
   CardContent,
   CardHeader,
   Link,
-  SxProps,
   Table,
   TableBody,
   TableCell,
   TableRow,
 } from '@mui/material';
 import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
-import { Recipe } from '@/types/Recipe';
+import type { Recipe } from '@/types/Recipe';
 
 const attributionRelationLabels = {
   'recipe author': 'Created by',

--- a/src/components/RecipeList/RecipeList.test.tsx
+++ b/src/components/RecipeList/RecipeList.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import RecipeList from './index';
-import { Recipe } from '@/types/Recipe';
+import type { Recipe } from '@/types/Recipe';
 
 let recipeCounter = 0;
 

--- a/src/components/RecipeList/index.tsx
+++ b/src/components/RecipeList/index.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { List, ListItem, ListItemText, ListSubheader, Paper } from '@mui/material';
 import ChevronRight from '@mui/icons-material/ChevronRight';
 import { getRecipeUrl } from '@/modules/url';
-import { Recipe } from '@/types/Recipe';
+import type { Recipe } from '@/types/Recipe';
 import { match } from 'ts-pattern';
 
 const ATTRIBUTION_PRIORITY = ['adapted by', 'recipe author', 'book', 'bar'];

--- a/src/components/SalineCalculator/index.tsx
+++ b/src/components/SalineCalculator/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { SxProps } from '@mui/material';
 import {
   Button,
   Card,
@@ -7,7 +8,6 @@ import {
   CardHeader,
   InputAdornment,
   Stack,
-  SxProps,
   TextField,
 } from '@mui/material';
 import { Suspense, useState } from 'react';

--- a/src/components/SearchableList/index.tsx
+++ b/src/components/SearchableList/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useMemo, ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import { useMemo } from 'react';
 import { List } from '@mui/material';
 import { fuzzySearch } from '@/modules/fuzzySearch';
 import groupByFirstLetter from '@/modules/groupByFirstLetter';

--- a/src/components/ServingSelector/index.tsx
+++ b/src/components/ServingSelector/index.tsx
@@ -2,7 +2,8 @@
 
 import { TextField, IconButton, InputAdornment } from '@mui/material';
 import { Add, Remove } from '@mui/icons-material';
-import { ChangeEvent, useState, useEffect } from 'react';
+import type { ChangeEvent } from 'react';
+import { useState, useEffect } from 'react';
 
 export default function ServingSelector({
   servings,

--- a/src/components/SourceAboutCard/Book.tsx
+++ b/src/components/SourceAboutCard/Book.tsx
@@ -9,7 +9,7 @@ import {
 } from '@mui/material';
 import BookIcon from '@mui/icons-material/Book';
 import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
-import { Book } from '@/types/Source';
+import type { Book } from '@/types/Source';
 
 export default function BookAboutCard({
   source,

--- a/src/components/SourceAboutCard/Podcast.tsx
+++ b/src/components/SourceAboutCard/Podcast.tsx
@@ -9,7 +9,7 @@ import {
 } from '@mui/material';
 import PodcastsIcon from '@mui/icons-material/Podcasts';
 import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
-import { Podcast } from '@/types/Source';
+import type { Podcast } from '@/types/Source';
 
 export default function PodcastAboutCard({
   source,

--- a/src/components/SourceAboutCard/Youtube.tsx
+++ b/src/components/SourceAboutCard/Youtube.tsx
@@ -10,8 +10,8 @@ import {
 import Video from '@/components/Video';
 import YouTubeIcon from '@mui/icons-material/YouTube';
 import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
-import { YoutubeRef } from '@/types/Ref';
-import { YoutubeChannel } from '@/types/Source';
+import type { YoutubeRef } from '@/types/Ref';
+import type { YoutubeChannel } from '@/types/Source';
 
 export default function YoutubeAboutCard({
   source,

--- a/src/components/VideoListCard/index.tsx
+++ b/src/components/VideoListCard/index.tsx
@@ -1,6 +1,7 @@
-import { Card, CardContent, CardHeader, SxProps } from '@mui/material';
+import type { SxProps } from '@mui/material';
+import { Card, CardContent, CardHeader } from '@mui/material';
 import Video from '@/components/Video';
-import { YoutubeRef } from '@/types/Ref';
+import type { YoutubeRef } from '@/types/Ref';
 
 export default function VideoListCard({
   refs,

--- a/src/modules/categories.ts
+++ b/src/modules/categories.ts
@@ -1,11 +1,11 @@
 import path from 'node:path';
 import memo from 'lodash/memoize';
 import fs from 'node:fs/promises';
-import { Category } from '@/types/Category';
+import type { Category } from '@/types/Category';
 import { CATEGORY_ROOT } from './constants';
 import { readJSONFile } from './fs';
 import slugify from '@sindresorhus/slugify';
-import { Ref } from '@/types/Ref';
+import type { Ref } from '@/types/Ref';
 
 export const getCategory = memo(async (category: string): Promise<Category> => {
   const filepath = path.join(CATEGORY_ROOT, `${category}.json`);

--- a/src/modules/conversion.ts
+++ b/src/modules/conversion.ts
@@ -1,4 +1,4 @@
-import { RecipeIngredient } from '@/types/Ingredient';
+import type { RecipeIngredient } from '@/types/Ingredient';
 
 const IMPERIAL_TO_ML = {
   tsp: 5,

--- a/src/modules/hasData.ts
+++ b/src/modules/hasData.ts
@@ -1,5 +1,5 @@
-import { Category } from '@/types/Category';
-import { RecipeIngredient, RootIngredient } from '@/types/Ingredient';
+import type { Category } from '@/types/Category';
+import type { RecipeIngredient, RootIngredient } from '@/types/Ingredient';
 
 export function categoryHasData(category: Category) {
   return category.description || category.parents.length > 0 || category.refs.length > 0;

--- a/src/modules/ingredients.ts
+++ b/src/modules/ingredients.ts
@@ -3,14 +3,14 @@ import fs from 'node:fs/promises';
 import slugify from '@sindresorhus/slugify';
 import memo from 'lodash/memoize';
 import uniqBy from 'lodash/uniqBy';
-import { RootIngredient } from '@/types/Ingredient';
+import type { RootIngredient } from '@/types/Ingredient';
 import { INGREDIENT_ROOT } from './constants';
 import { readJSONFile } from './fs';
 import { getCategoriesPerParent, getCategory } from './categories';
-import { Ref } from '@/types/Ref';
-import { Category } from '@/types/Category';
+import type { Ref } from '@/types/Ref';
+import type { Category } from '@/types/Category';
 import { match } from 'ts-pattern';
-import { Recipe } from '@/types/Recipe';
+import type { Recipe } from '@/types/Recipe';
 import { getAllRecipes } from './recipes';
 
 function toAlphaSort<I extends { name: string }>(arr: I[]) {

--- a/src/modules/params.ts
+++ b/src/modules/params.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { Source } from '@/types/Source';
+import type { Source } from '@/types/Source';
 import { INGREDIENT_ROOT, RECIPE_ROOT } from './constants';
 
 export async function getRecipePageParams(): Promise<

--- a/src/modules/recipes.ts
+++ b/src/modules/recipes.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import fs from 'node:fs/promises';
-import { Recipe } from '@/types/Recipe';
-import { Source } from '@/types/Source';
+import type { Recipe } from '@/types/Recipe';
+import type { Source } from '@/types/Source';
 import slugify from '@sindresorhus/slugify';
 import memo from 'lodash/memoize';
 import { readJSONFile } from './fs';
@@ -10,7 +10,7 @@ import { getIngredient } from './ingredients';
 import { getCategory, getChildCategories } from './categories';
 import { getSource } from './sources';
 import { match } from 'ts-pattern';
-import { Category } from '@/types/Category';
+import type { Category } from '@/types/Category';
 import { uniqBy } from 'lodash';
 
 function toAlphaSort<I extends { name: string }>(arr: I[]) {

--- a/src/modules/scaling.ts
+++ b/src/modules/scaling.ts
@@ -1,4 +1,4 @@
-import { RecipeIngredient } from '@/types/Ingredient';
+import type { RecipeIngredient } from '@/types/Ingredient';
 
 type ScaledQuantity = {
   amount: number;

--- a/src/modules/searchText.test.ts
+++ b/src/modules/searchText.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { getRecipeSearchText } from './searchText';
-import { Recipe } from '@/types/Recipe';
-import { RecipeIngredient } from '@/types/Ingredient';
-import { Category } from '@/types/Category';
+import type { Recipe } from '@/types/Recipe';
+import type { RecipeIngredient } from '@/types/Ingredient';
+import type { Category } from '@/types/Category';
 
 const mockCategory: Category = {
   name: 'Aged Rum',

--- a/src/modules/sources.ts
+++ b/src/modules/sources.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs/promises';
-import { Book, Source, YoutubeChannel, Podcast } from '@/types/Source';
+import type { Book, Source, YoutubeChannel, Podcast } from '@/types/Source';
 import path from 'node:path';
 import memo from 'lodash/memoize';
 import { readJSONFile } from './fs';

--- a/src/modules/technique.test.ts
+++ b/src/modules/technique.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { formatIngredientName } from './technique';
-import { RecipeIngredient } from '@/types/Ingredient';
+import type { RecipeIngredient } from '@/types/Ingredient';
 
 // Helper to create a basic ingredient for testing
 function createIngredient(overrides: Partial<RecipeIngredient> = {}): RecipeIngredient {

--- a/src/modules/technique.ts
+++ b/src/modules/technique.ts
@@ -1,5 +1,5 @@
 import { match } from 'ts-pattern';
-import { RecipeIngredient } from '@/types/Ingredient';
+import type { RecipeIngredient, Technique } from '@/types/Ingredient';
 
 const cutTypeNames = {
   chunked: { countable: true, forms: ['chunk', 'chunks'] },
@@ -19,7 +19,7 @@ const cutTypeNames = {
  * Converts a technique object to a human-readable string for display
  */
 function formatSingleTechnique(
-  technique: import('@/types/Ingredient').Technique,
+  technique: Technique,
   name: string,
   ingredient: RecipeIngredient,
 ): string {

--- a/src/modules/url.ts
+++ b/src/modules/url.ts
@@ -1,6 +1,6 @@
-import { RecipeIngredient } from '@/types/Ingredient';
-import { Recipe } from '@/types/Recipe';
-import { Source } from '@/types/Source';
+import type { RecipeIngredient } from '@/types/Ingredient';
+import type { Recipe } from '@/types/Recipe';
+import type { Source } from '@/types/Source';
 import slugify from '@sindresorhus/slugify';
 
 export function getRecipeUrl(recipe: Recipe) {

--- a/src/testing/index.tsx
+++ b/src/testing/index.tsx
@@ -1,7 +1,8 @@
-import { render, RenderOptions } from '@testing-library/react';
+import type { RenderOptions } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
-import { ComponentProps, ReactNode } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 import { MemoryRouterProvider } from 'next-router-mock/MemoryRouterProvider';
 
 type NuqsRenderOptions = RenderOptions & {

--- a/src/types/Recipe.ts
+++ b/src/types/Recipe.ts
@@ -1,6 +1,6 @@
-import { Source } from './Source';
-import { Ref } from './Ref';
-import { RecipeIngredient } from './Ingredient';
+import type { Source } from './Source';
+import type { Ref } from './Ref';
+import type { RecipeIngredient } from './Ingredient';
 
 type BarAttribution = {
   relation: 'bar';


### PR DESCRIPTION
## Summary

- Adds `@typescript-eslint/consistent-type-imports` rule to eslint config as an error
- Converts all type-only imports across 48 files to use explicit `import type` syntax
- Fixes one inline type import pattern (`import('@/types/Ingredient').Technique`) by extracting it to a proper type import

## Test plan

- [x] `yarn lint` passes (only pre-existing warning about unused variable in check-data.ts)