### PR TITLE
feat: add contextual search to bars list page (M8)

### DIFF
--- a/src/app/list/bars/BarsClient.tsx
+++ b/src/app/list/bars/BarsClient.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { Typography } from '@mui/material';
+import { Card, CardHeader } from '@mui/material';
+import { useQueryState } from 'nuqs';
+import { LinkList, LinkListItem } from '@/components/LinkList';
+import SearchableList from '@/components/SearchableList';
+import SearchHeader from '@/components/SearchHeader';
+import { getBarSearchText } from '@/modules/searchText';
+import { getBarRecipesUrl } from '@/modules/url';
+
+export default function BarsClient({
+  bars,
+}: {
+  bars: { name: string; location?: string; recipeCount: number }[];
+}) {
+  const [searchTerm, setSearchTerm] = useQueryState('search');
+
+  const emptyState = (
+    <Card sx={{ m: 2 }}>
+      <CardHeader title="No results found" />
+    </Card>
+  );
+
+  return (
+    <>
+      <SearchHeader
+        title="All Bars"
+        searchTerm={searchTerm}
+        onSearchChange={setSearchTerm}
+      />
+      <SearchableList
+        items={bars}
+        getSearchText={getBarSearchText}
+        renderItem={(items, header) => (
+          <LinkList
+            items={items}
+            header={header}
+            renderItem={(bar) => (
+              <LinkListItem
+                key={bar.name + (bar.location ?? '')}
+                href={getBarRecipesUrl(bar)}
+                primary={bar.name}
+                secondary={bar.location}
+                tertiary={
+                  <Typography color="textSecondary">{bar.recipeCount}</Typography>
+                }
+              />
+            )}
+          />
+        )}
+        searchTerm={searchTerm}
+        emptyState={emptyState}
+      />
+    </>
+  );
+}

--- a/src/app/list/bars/page.test.tsx
+++ b/src/app/list/bars/page.test.tsx
@@ -1,0 +1,147 @@
+import { screen, within } from '@testing-library/react';
+import mockRouter from 'next-router-mock';
+import { vi, describe, it, expect } from 'vitest';
+import { getBarRecipesUrl } from '@/modules/url';
+import { setupApp } from '@/testing';
+import BarListPage from './page';
+
+// Real bar data from the codebase
+const TEST_BAR = { name: 'Sunken Harbor Club', location: 'Brooklyn, NY' };
+
+describe('BarListPage', () => {
+  it('shows search input, title and list', async () => {
+    setupApp(await BarListPage());
+
+    expect(screen.getByText('All Bars')).toBeInTheDocument();
+    expect(screen.getByRole('searchbox')).toBeInTheDocument();
+    expect(screen.getByRole('list')).toBeInTheDocument();
+  });
+
+  it('typing filters bar list', async () => {
+    const { user } = setupApp(await BarListPage());
+
+    const input = screen.getByRole('searchbox');
+    await user.type(input, 'sunken');
+
+    const resultList = screen.getByRole('list');
+    expect(resultList).toHaveTextContent(TEST_BAR.name);
+  });
+
+  it('filters bars by location', async () => {
+    const { user } = setupApp(await BarListPage());
+
+    const input = screen.getByRole('searchbox');
+    await user.type(input, 'brooklyn');
+
+    const resultList = screen.getByRole('list');
+    expect(resultList).toHaveTextContent(TEST_BAR.name);
+  });
+
+  it('clearing search shows all bars grouped by letter', async () => {
+    const { user } = setupApp(await BarListPage(), {
+      nuqsOptions: { searchParams: { search: 'sunken' } },
+    });
+
+    const input = screen.getByRole('searchbox');
+    expect(input).toHaveValue('sunken');
+
+    await user.clear(input);
+
+    const groups = screen.queryAllByRole('group');
+    expect(groups.length).toBeGreaterThan(0);
+  });
+
+  it('URL updates with search param when typing', async () => {
+    const onUrlUpdate = vi.fn();
+    const { user } = setupApp(await BarListPage(), {
+      nuqsOptions: { onUrlUpdate },
+    });
+
+    const input = screen.getByRole('searchbox');
+    await user.type(input, 'bar');
+
+    expect(onUrlUpdate).toHaveBeenLastCalledWith(
+      expect.objectContaining({ queryString: '?search=bar' }),
+    );
+  });
+
+  it('shows no results when search has no matches', async () => {
+    const { user } = setupApp(await BarListPage());
+
+    const input = screen.getByRole('searchbox');
+    await user.type(input, 'xyznonexistent');
+
+    expect(screen.getByText('No results found')).toBeInTheDocument();
+  });
+
+  it('does not show SearchAllLink when no results (not searching recipes)', async () => {
+    const { user } = setupApp(await BarListPage());
+
+    const input = screen.getByRole('searchbox');
+    await user.type(input, 'xyznonexistent');
+
+    expect(screen.getByText('No results found')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /search all recipes/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('bar items link to correct bar recipes pages', async () => {
+    setupApp(await BarListPage());
+
+    const link = screen.getByRole('link', { name: new RegExp(TEST_BAR.name, 'i') });
+    expect(link).toHaveAttribute('href', getBarRecipesUrl(TEST_BAR));
+  });
+
+  it('loads with search term from URL', async () => {
+    setupApp(await BarListPage(), {
+      nuqsOptions: { searchParams: { search: 'sunken' } },
+    });
+
+    const input = screen.getByRole('searchbox');
+    expect(input).toHaveValue('sunken');
+
+    const resultList = screen.getByRole('list');
+    expect(resultList).toHaveTextContent(TEST_BAR.name);
+  });
+
+  it('groups bars by first letter when not searching', async () => {
+    setupApp(await BarListPage());
+
+    const groups = screen.getAllByRole('group');
+    expect(groups.length).toBeGreaterThan(0);
+
+    const firstGroup = groups[0]!;
+    const items = within(firstGroup).getAllByRole('listitem');
+    expect(items.length).toBeGreaterThan(0);
+  });
+
+  it('back button navigates correctly', async () => {
+    await mockRouter.push('/');
+    await mockRouter.push('/list/bars');
+
+    const backSpy = vi.spyOn(mockRouter, 'back');
+
+    const { user } = setupApp(await BarListPage());
+
+    const backButton = screen.getByRole('button', { name: /go back/i });
+    await user.click(backButton);
+
+    expect(backSpy).toHaveBeenCalled();
+    backSpy.mockRestore();
+  });
+
+  it('shows recipe count for each bar', async () => {
+    setupApp(await BarListPage());
+
+    const link = screen.getByRole('link', { name: new RegExp(TEST_BAR.name, 'i') });
+    expect(link).toHaveTextContent(/\d+/);
+  });
+
+  it('shows bar location as secondary text', async () => {
+    setupApp(await BarListPage());
+
+    const link = screen.getByRole('link', { name: new RegExp(TEST_BAR.name, 'i') });
+    expect(link).toHaveTextContent(TEST_BAR.location);
+  });
+});

--- a/src/app/list/bars/page.tsx
+++ b/src/app/list/bars/page.tsx
@@ -1,20 +1,7 @@
 import type { Metadata } from 'next';
-import { ChevronRight } from '@mui/icons-material';
-import {
-  List,
-  ListItem,
-  ListItemText,
-  ListSubheader,
-  Paper,
-  Stack,
-  Typography,
-} from '@mui/material';
-import Link from 'next/link';
 import { Suspense } from 'react';
-import AppHeader from '@/components/AppHeader';
-import groupByFirstLetter from '@/modules/groupByFirstLetter';
 import { getAllRecipes } from '@/modules/recipes';
-import { getBarRecipesUrl } from '@/modules/url';
+import BarsClient from './BarsClient';
 
 export const metadata: Metadata = {
   title: 'Cocktail Index | Bars list',
@@ -45,49 +32,13 @@ export default async function BarListPage() {
   });
 
   // Convert to array and sort
-  const bars = Array.from(barsMap.values());
-
-  // Group bars by first letter
-  const barGroups = groupByFirstLetter(bars);
+  const bars = Array.from(barsMap.values()).toSorted((a, b) =>
+    a.name.localeCompare(b.name),
+  );
 
   return (
     <Suspense>
-      <AppHeader title="All Bars" />
-      <List>
-        {barGroups.map(([letter, bars]) => {
-          if (!bars) return null;
-
-          return (
-            <li key={letter}>
-              <List>
-                <ListSubheader>{letter}</ListSubheader>
-                <Paper square>
-                  {bars.map((bar) => (
-                    <Link
-                      href={getBarRecipesUrl(bar)}
-                      key={bar.name + (bar.location ?? '')}
-                    >
-                      <ListItem
-                        divider
-                        secondaryAction={
-                          <Stack direction="row" spacing={1}>
-                            <Typography color="textSecondary">
-                              {bar.recipeCount}
-                            </Typography>
-                            <ChevronRight />
-                          </Stack>
-                        }
-                      >
-                        <ListItemText primary={bar.name} secondary={bar.location} />
-                      </ListItem>
-                    </Link>
-                  ))}
-                </Paper>
-              </List>
-            </li>
-          );
-        })}
-      </List>
+      <BarsClient bars={bars} />
     </Suspense>
   );
 }

--- a/src/modules/searchText.ts
+++ b/src/modules/searchText.ts
@@ -57,3 +57,11 @@ export function getIngredientOrCategorySearchText(
 
   return normalize(`${item.name} ${categoryNames}`);
 }
+
+/**
+ * Extracts searchable text from a bar.
+ * Includes bar name and location.
+ */
+export function getBarSearchText(bar: { name: string; location?: string }): string {
+  return normalize(`${bar.name} ${bar.location ?? ''}`);
+}


### PR DESCRIPTION
## Summary
- Add search functionality to the bars list page
- Search by bar name and location
- Uses `SearchHeader` and `SearchableList` pattern for consistent UI

## Test plan
- [x] Search input appears in header
- [x] Filtering works by name
- [x] Filtering works by location
- [x] Empty state shows "No results"
- [x] Unit tests pass