### PR TITLE
feat: add contextual search to authors list (M9)

### DIFF
--- a/src/app/list/authors/AuthorsClient.tsx
+++ b/src/app/list/authors/AuthorsClient.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { Card, CardHeader, Typography } from '@mui/material';
+import { useQueryState } from 'nuqs';
+import { LinkList, LinkListItem } from '@/components/LinkList';
+import SearchableList from '@/components/SearchableList';
+import SearchHeader from '@/components/SearchHeader';
+import { getAuthorSearchText } from '@/modules/searchText';
+import { getAuthorRecipesUrl } from '@/modules/url';
+
+export default function AuthorsClient({
+  authors,
+}: {
+  authors: { name: string; recipeCount: number }[];
+}) {
+  const [searchTerm, setSearchTerm] = useQueryState('search');
+
+  const emptyState = (
+    <Card sx={{ m: 2 }}>
+      <CardHeader title="No results found" />
+    </Card>
+  );
+
+  return (
+    <>
+      <SearchHeader
+        title="All Authors"
+        searchTerm={searchTerm}
+        onSearchChange={setSearchTerm}
+      />
+      <SearchableList
+        items={authors}
+        getSearchText={getAuthorSearchText}
+        renderItem={(items, header) => (
+          <LinkList
+            items={items}
+            header={header}
+            renderItem={(author) => (
+              <LinkListItem
+                key={author.name}
+                href={getAuthorRecipesUrl(author.name)}
+                primary={author.name}
+                tertiary={
+                  <Typography color="textSecondary">{author.recipeCount}</Typography>
+                }
+              />
+            )}
+          />
+        )}
+        searchTerm={searchTerm}
+        emptyState={emptyState}
+      />
+    </>
+  );
+}

--- a/src/app/list/authors/page.test.tsx
+++ b/src/app/list/authors/page.test.tsx
@@ -1,0 +1,128 @@
+import { screen, within } from '@testing-library/react';
+import mockRouter from 'next-router-mock';
+import { vi, describe, it, expect } from 'vitest';
+import { getAuthorRecipesUrl } from '@/modules/url';
+import { setupApp } from '@/testing';
+import AuthorListPage from './page';
+
+// Real author from the codebase with multiple recipes
+const TEST_AUTHOR = 'Garret Richard';
+
+describe('AuthorListPage', () => {
+  it('shows search input, title and list', async () => {
+    setupApp(await AuthorListPage());
+
+    expect(screen.getByText('All Authors')).toBeInTheDocument();
+    expect(screen.getByRole('searchbox')).toBeInTheDocument();
+    expect(screen.getByRole('list')).toBeInTheDocument();
+  });
+
+  it('typing filters author list', async () => {
+    const { user } = setupApp(await AuthorListPage());
+
+    const input = screen.getByRole('searchbox');
+    await user.type(input, 'garret');
+
+    const resultList = screen.getByRole('list');
+    expect(resultList).toHaveTextContent(TEST_AUTHOR);
+  });
+
+  it('clearing search shows all authors grouped by letter', async () => {
+    const { user } = setupApp(await AuthorListPage(), {
+      nuqsOptions: { searchParams: { search: 'garret' } },
+    });
+
+    const input = screen.getByRole('searchbox');
+    await user.clear(input);
+
+    const groups = screen.getAllByRole('group');
+    expect(groups.length).toBeGreaterThan(0);
+  });
+
+  it('URL updates with search param when typing', async () => {
+    const onUrlUpdate = vi.fn();
+    const { user } = setupApp(await AuthorListPage(), {
+      nuqsOptions: { onUrlUpdate },
+    });
+
+    const input = screen.getByRole('searchbox');
+    await user.type(input, 'john');
+
+    expect(onUrlUpdate).toHaveBeenLastCalledWith(
+      expect.objectContaining({ queryString: '?search=john' }),
+    );
+  });
+
+  it('shows no results when search has no matches', async () => {
+    const { user } = setupApp(await AuthorListPage());
+
+    const input = screen.getByRole('searchbox');
+    await user.type(input, 'xyznonexistent');
+
+    expect(screen.getByText('No results found')).toBeInTheDocument();
+  });
+
+  it('does not show SearchAllLink when no results (not searching recipes)', async () => {
+    const { user } = setupApp(await AuthorListPage());
+
+    const input = screen.getByRole('searchbox');
+    await user.type(input, 'xyznonexistent');
+
+    expect(screen.getByText('No results found')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /search all recipes/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('author items link to correct author recipes pages', async () => {
+    setupApp(await AuthorListPage());
+
+    const link = screen.getByRole('link', { name: new RegExp(TEST_AUTHOR, 'i') });
+    expect(link).toHaveAttribute('href', getAuthorRecipesUrl(TEST_AUTHOR));
+  });
+
+  it('loads with search term from URL', async () => {
+    setupApp(await AuthorListPage(), {
+      nuqsOptions: { searchParams: { search: 'garret' } },
+    });
+
+    const input = screen.getByRole('searchbox');
+    expect(input).toHaveValue('garret');
+
+    const resultList = screen.getByRole('list');
+    expect(resultList).toHaveTextContent(TEST_AUTHOR);
+  });
+
+  it('groups authors by first letter when not searching', async () => {
+    setupApp(await AuthorListPage());
+
+    const groups = screen.getAllByRole('group');
+    expect(groups.length).toBeGreaterThan(0);
+
+    const firstGroup = groups[0]!;
+    const items = within(firstGroup).getAllByRole('listitem');
+    expect(items.length).toBeGreaterThan(0);
+  });
+
+  it('back button navigates correctly', async () => {
+    await mockRouter.push('/');
+    await mockRouter.push('/list/authors');
+
+    const backSpy = vi.spyOn(mockRouter, 'back');
+
+    const { user } = setupApp(await AuthorListPage());
+
+    const backButton = screen.getByRole('button', { name: /go back/i });
+    await user.click(backButton);
+
+    expect(backSpy).toHaveBeenCalled();
+    backSpy.mockRestore();
+  });
+
+  it('shows recipe count for each author', async () => {
+    setupApp(await AuthorListPage());
+
+    const link = screen.getByRole('link', { name: new RegExp(TEST_AUTHOR, 'i') });
+    expect(link).toHaveTextContent(/\d+/);
+  });
+});

--- a/src/app/list/authors/page.tsx
+++ b/src/app/list/authors/page.tsx
@@ -1,20 +1,7 @@
 import type { Metadata } from 'next';
-import { ChevronRight } from '@mui/icons-material';
-import {
-  List,
-  ListItem,
-  ListItemText,
-  ListSubheader,
-  Paper,
-  Stack,
-  Typography,
-} from '@mui/material';
-import Link from 'next/link';
 import { Suspense } from 'react';
-import AppHeader from '@/components/AppHeader';
-import groupByFirstLetter from '@/modules/groupByFirstLetter';
 import { getAllRecipes } from '@/modules/recipes';
-import { getAuthorRecipesUrl } from '@/modules/url';
+import AuthorsClient from './AuthorsClient';
 
 export const metadata: Metadata = {
   title: 'Cocktail Index | Authors list',
@@ -45,47 +32,12 @@ export default async function AuthorListPage() {
       });
   });
 
-  // Convert to array and sort
+  // Convert to array
   const authors = Array.from(authorsMap.values());
-
-  // Group authors by first letter
-  const authorGroups = groupByFirstLetter(authors);
 
   return (
     <Suspense>
-      <AppHeader title="All Authors" />
-      <List>
-        {authorGroups.map(([letter, authors]) => {
-          if (!authors) return null;
-
-          return (
-            <li key={letter}>
-              <List>
-                <ListSubheader>{letter}</ListSubheader>
-                <Paper square>
-                  {authors.map((author) => (
-                    <Link href={getAuthorRecipesUrl(author.name)} key={author.name}>
-                      <ListItem
-                        divider
-                        secondaryAction={
-                          <Stack direction="row" spacing={1}>
-                            <Typography color="textSecondary">
-                              {author.recipeCount}
-                            </Typography>
-                            <ChevronRight />
-                          </Stack>
-                        }
-                      >
-                        <ListItemText primary={author.name} />
-                      </ListItem>
-                    </Link>
-                  ))}
-                </Paper>
-              </List>
-            </li>
-          );
-        })}
-      </List>
+      <AuthorsClient authors={authors} />
     </Suspense>
   );
 }

--- a/src/modules/searchText.ts
+++ b/src/modules/searchText.ts
@@ -65,3 +65,10 @@ export function getIngredientOrCategorySearchText(
 export function getBarSearchText(bar: { name: string; location?: string }): string {
   return normalize(`${bar.name} ${bar.location ?? ''}`);
 }
+
+/**
+ * Extracts searchable text from an author.
+ */
+export function getAuthorSearchText(item: { name: string }): string {
+  return normalize(item.name);
+}


### PR DESCRIPTION
## Summary
- Add search functionality to the authors list page
- Search by author name
- Uses `SearchHeader` and `SearchableList` pattern for consistent UI

## Test plan
- [x] Search input appears in header
- [x] Filtering works by name
- [x] Empty state shows "No results"
- [x] Unit tests pass