### PR TITLE
feat: add contextual search to category page (M12)

### DIFF
--- a/src/app/category/[slug]/CategoryClient.tsx
+++ b/src/app/category/[slug]/CategoryClient.tsx
@@ -1,24 +1,65 @@
 'use client';
 
-import { useCallback } from 'react';
+import { Card, CardContent, CardHeader, Stack } from '@mui/material';
+import { useQueryState } from 'nuqs';
+import { useCallback, useMemo } from 'react';
 import type { Category } from '@/types/Category';
+import type { RootIngredient } from '@/types/Ingredient';
 import type { Recipe } from '@/types/Recipe';
-import { LinkListItem } from '@/components/LinkList';
+import AppHeader from '@/components/AppHeader';
+import CategoryName from '@/components/CategoryName';
+import FixBugCard from '@/components/FixBugCard';
+import { LinkList, LinkListItem } from '@/components/LinkList';
 import Quantity from '@/components/Quantity';
 import RecipeList, { getRecipeAttribution } from '@/components/RecipeList';
+import SearchableList from '@/components/SearchableList';
+import SearchAllLink from '@/components/SearchAllLink';
+import SearchHeader from '@/components/SearchHeader';
+import Video from '@/components/Video';
+import VideoListCard from '@/components/VideoListCard';
 import useNameIsUnique from '@/hooks/useNameIsUnique';
-import { getRecipeUrl } from '@/modules/url';
+import { ingredientHasData } from '@/modules/hasData';
+import { getRecipeSearchText } from '@/modules/searchText';
+import { getIngredientUrl, getRecipeUrl } from '@/modules/url';
 
 export default function CategoryClient({
   category,
+  members,
+  substitutes,
   relatedRecipes,
-  categorySlugs,
+  childCategories,
 }: {
   category: Category;
+  members: RootIngredient[];
+  substitutes: RootIngredient[];
   relatedRecipes: Recipe[];
-  categorySlugs: string[];
+  childCategories: Category[];
 }) {
+  const [searchTerm, setSearchTerm] = useQueryState('search');
   const recipeNameIsUnique = useNameIsUnique(relatedRecipes);
+  const isSearching = searchTerm != null && searchTerm.trim() !== '';
+
+  const categorySlugs = useMemo(
+    () => [category.slug, ...childCategories.map((c) => c.slug)],
+    [category.slug, childCategories],
+  );
+
+  const { firstVideo, additionalVideos } = useMemo(() => {
+    const videos = category.refs.filter((ref) => ref.type === 'youtube');
+    return {
+      firstVideo: videos[0],
+      additionalVideos: videos.slice(1),
+    };
+  }, [category.refs]);
+
+  const emptyState = (
+    <>
+      <Card sx={{ m: 2 }}>
+        <CardHeader title="No results found" />
+      </Card>
+      <SearchAllLink searchTerm={searchTerm} />
+    </>
+  );
 
   const renderRecipe = useCallback(
     (recipe: Recipe) => {
@@ -47,10 +88,99 @@ export default function CategoryClient({
   );
 
   return (
-    <RecipeList
-      recipes={relatedRecipes}
-      header={`Recipes using ${category.name}`}
-      renderRecipe={renderRecipe}
-    />
+    <>
+      {relatedRecipes.length > 0 ? (
+        <SearchHeader
+          title={category.name}
+          searchTerm={searchTerm}
+          onSearchChange={setSearchTerm}
+        />
+      ) : (
+        <AppHeader title={category.name} />
+      )}
+      {isSearching ? (
+        <SearchableList
+          items={relatedRecipes}
+          getSearchText={getRecipeSearchText}
+          renderItem={(recipes, header) => (
+            <RecipeList recipes={recipes} header={header} renderRecipe={renderRecipe} />
+          )}
+          searchTerm={searchTerm}
+          emptyState={emptyState}
+        />
+      ) : (
+        <>
+          {firstVideo && <Video id={firstVideo.videoId} start={firstVideo.start} />}
+          {(category.description || category.parents.length > 0) && (
+            <Card sx={{ m: 1 }}>
+              {category.description && <CardContent>{category.description}</CardContent>}
+              {category.parents.length > 0 && (
+                <CardContent>
+                  <b>{category.name}</b> is a subset of
+                  <Stack
+                    direction="row"
+                    alignItems="baseline"
+                    spacing={1}
+                    sx={{ flexWrap: 'wrap' }}
+                  >
+                    {category.parents.map((parentCategory) => (
+                      <CategoryName key={parentCategory.slug} category={parentCategory} />
+                    ))}
+                  </Stack>
+                </CardContent>
+              )}
+            </Card>
+          )}
+          {members.length > 0 && (
+            <LinkList
+              header={`Examples of ${category.name}`}
+              items={members}
+              renderItem={(ingredient) => (
+                <LinkListItem
+                  key={ingredient.slug}
+                  href={
+                    ingredientHasData(ingredient)
+                      ? getIngredientUrl(ingredient)
+                      : undefined
+                  }
+                  primary={ingredient.name}
+                />
+              )}
+            />
+          )}
+          {substitutes.length > 0 && (
+            <LinkList
+              header={`Potential substitutes for ${category.name}`}
+              items={substitutes}
+              renderItem={(ingredient) => (
+                <LinkListItem
+                  key={ingredient.slug}
+                  href={
+                    ingredientHasData(ingredient)
+                      ? getIngredientUrl(ingredient)
+                      : undefined
+                  }
+                  primary={ingredient.name}
+                />
+              )}
+            />
+          )}
+          {additionalVideos.length > 0 && (
+            <VideoListCard title="Other videos" refs={additionalVideos} sx={{ m: 1 }} />
+          )}
+          {relatedRecipes.length > 0 && (
+            <RecipeList
+              recipes={relatedRecipes}
+              header={`Recipes using ${category.name}`}
+              renderRecipe={renderRecipe}
+            />
+          )}
+          <FixBugCard
+            fixUrl={`https://github.com/SBoudrias/cocktails/edit/main/src/data/categories/${category.slug}.json`}
+            sx={{ m: 1 }}
+          />
+        </>
+      )}
+    </>
   );
 }

--- a/src/app/category/[slug]/page.tsx
+++ b/src/app/category/[slug]/page.tsx
@@ -1,30 +1,12 @@
 import type { Metadata } from 'next';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
-import {
-  Card,
-  CardContent,
-  List,
-  ListItem,
-  ListItemText,
-  ListSubheader,
-  Paper,
-  Stack,
-} from '@mui/material';
-import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import AppHeader from '@/components/AppHeader';
-import CategoryName from '@/components/CategoryName';
-import FixBugCard from '@/components/FixBugCard';
-import Video from '@/components/Video';
-import VideoListCard from '@/components/VideoListCard';
+import { Suspense } from 'react';
 import { getCategory, getChildCategories } from '@/modules/categories';
 import { CATEGORY_ROOT } from '@/modules/constants';
-import { ingredientHasData } from '@/modules/hasData';
 import { getIngredientsForCategory } from '@/modules/ingredients';
 import { getRecipeByCategory } from '@/modules/recipes';
-import { getIngredientUrl } from '@/modules/url';
 import CategoryClient from './CategoryClient';
 
 type Params = { slug: string };
@@ -67,97 +49,16 @@ export default async function CategoryPage({ params }: { params: Promise<Params>
   const [members, substitutes] = await getIngredientsForCategory(category);
   const relatedRecipes = await getRecipeByCategory(category);
   const childCategories = await getChildCategories(category);
-  const categorySlugs = [category.slug, ...childCategories.map((c) => c.slug)];
-
-  const videos = category.refs.filter((ref) => ref.type === 'youtube');
-  const firstVideo = videos.shift();
 
   return (
-    <>
-      <AppHeader title={category.name} />
-      {firstVideo && <Video id={firstVideo.videoId} start={firstVideo.start} />}
-      {(category.description || category.parents.length > 0) && (
-        <Card sx={{ m: 1 }}>
-          {category.description && <CardContent>{category.description}</CardContent>}
-          {category.parents.length > 0 && (
-            <CardContent>
-              <b>{category.name}</b> is a subset of
-              <Stack
-                direction="row"
-                alignItems="baseline"
-                spacing={1}
-                sx={{ flexWrap: 'wrap' }}
-              >
-                {category.parents.map((category) => (
-                  <CategoryName key={category.slug} category={category} />
-                ))}
-              </Stack>
-            </CardContent>
-          )}
-        </Card>
-      )}
-      {members.length > 0 && (
-        <List>
-          <ListSubheader>Examples of {category.name}</ListSubheader>
-          <Paper square>
-            {members.map((ingredient) => {
-              if (ingredientHasData(ingredient)) {
-                return (
-                  <Link key={ingredient.slug} href={getIngredientUrl(ingredient)}>
-                    <ListItem divider secondaryAction={<ChevronRightIcon />}>
-                      <ListItemText>{ingredient.name}</ListItemText>
-                    </ListItem>
-                  </Link>
-                );
-              }
-
-              return (
-                <ListItem key={ingredient.slug} divider>
-                  <ListItemText>{ingredient.name}</ListItemText>
-                </ListItem>
-              );
-            })}
-          </Paper>
-        </List>
-      )}
-      {substitutes.length > 0 && (
-        <List>
-          <ListSubheader>Potential substitutes for {category.name}</ListSubheader>
-          <Paper square>
-            {substitutes.map((ingredient) => {
-              if (ingredientHasData(ingredient)) {
-                return (
-                  <Link key={ingredient.slug} href={getIngredientUrl(ingredient)}>
-                    <ListItem divider secondaryAction={<ChevronRightIcon />}>
-                      <ListItemText>{ingredient.name}</ListItemText>
-                    </ListItem>
-                  </Link>
-                );
-              }
-
-              return (
-                <ListItem key={ingredient.slug} divider>
-                  <ListItemText>{ingredient.name}</ListItemText>
-                </ListItem>
-              );
-            })}
-          </Paper>
-        </List>
-      )}
-      {videos.length > 0 && (
-        <VideoListCard title="Other videos" refs={videos} sx={{ m: 1 }} />
-      )}
-      {relatedRecipes.length > 0 && (
-        <CategoryClient
-          category={category}
-          relatedRecipes={relatedRecipes}
-          categorySlugs={categorySlugs}
-        />
-      )}
-      <FixBugCard
-        fixUrl={`https://github.com/SBoudrias/cocktails/edit/main/src/data/categories/${slug}.json`}
-        sx={{ m: 1 }}
+    <Suspense>
+      <CategoryClient
+        category={category}
+        members={members}
+        substitutes={substitutes}
+        relatedRecipes={relatedRecipes}
+        childCategories={childCategories}
       />
-    </>
+    </Suspense>
   );
 }

--- a/src/components/LinkList/index.tsx
+++ b/src/components/LinkList/index.tsx
@@ -8,26 +8,26 @@ export function LinkListItem({
   secondary,
   tertiary,
 }: {
-  href: string;
+  href?: string;
   primary: React.ReactNode;
   secondary?: React.ReactNode;
   tertiary?: React.ReactNode;
 }) {
-  return (
-    <Link href={href}>
-      <ListItem divider secondaryAction={<ChevronRight />}>
-        <Stack
-          direction="row"
-          justifyContent="space-between"
-          alignItems="center"
-          width="100%"
-        >
-          <ListItemText primary={primary} secondary={secondary} />
-          {tertiary}
-        </Stack>
-      </ListItem>
-    </Link>
+  const item = (
+    <ListItem divider secondaryAction={href ? <ChevronRight /> : undefined}>
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        width="100%"
+      >
+        <ListItemText primary={primary} secondary={secondary} />
+        {tertiary}
+      </Stack>
+    </ListItem>
   );
+
+  return href ? <Link href={href}>{item}</Link> : item;
 }
 
 export function LinkList<T>({


### PR DESCRIPTION
## Summary
- Add search functionality to single category detail pages
- When searching, hides non-recipe content and shows filtered recipe results
- When not searching, shows full page with recipes at bottom under "Recipes using {name}"
- Categories without recipes use AppHeader instead of SearchHeader (no search needed)
- Uses RecipeList and LinkList for consistent rendering
- LinkListItem now supports optional href (renders without link when undefined)
- Computed values (categorySlugs, videos) moved inside client component

## Test plan
- [x] Search input appears in header for categories with recipes
- [x] Categories without recipes show regular header (no search)
- [x] Filtering works for recipes in category
- [x] Non-recipe content hides when searching
- [x] Content restores when search cleared
- [x] SearchAllLink appears in empty state
- [x] Unit tests pass (14 tests)