### PR TITLE
feat: enable Next.js typedRoutes for compile-time route validation

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,8 +3,7 @@ const nextConfig = {
   output: 'export',
   basePath: '/cocktails',
   reactStrictMode: true,
-  // TODO: enable
-  // typedRoutes: true,
+  typedRoutes: true,
 };
 
 export default nextConfig;

--- a/src/app/search/SearchRedirect.tsx
+++ b/src/app/search/SearchRedirect.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import type { Route } from 'next';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { useEffect } from 'react';
+import { getRecipeListUrl } from '@/modules/url';
 
 export default function SearchRedirect() {
   const router = useRouter();
@@ -10,8 +12,8 @@ export default function SearchRedirect() {
   useEffect(() => {
     const search = searchParams.get('search');
     const url = search
-      ? `/list/recipes?search=${encodeURIComponent(search)}`
-      : '/list/recipes';
+      ? (`${getRecipeListUrl()}?${new URLSearchParams({ search })}` as Route)
+      : getRecipeListUrl();
     router.replace(url);
   }, [router, searchParams]);
 

--- a/src/app/theme.tsx
+++ b/src/app/theme.tsx
@@ -6,7 +6,7 @@ import NextLink from 'next/link';
 import { forwardRef } from 'react';
 
 const LinkBehaviour = forwardRef(function LinkBehaviour(
-  props: LinkProps,
+  props: LinkProps<string>,
   ref: Ref<HTMLAnchorElement>,
 ) {
   return <NextLink ref={ref} {...props} />;

--- a/src/components/IngredientList/index.tsx
+++ b/src/components/IngredientList/index.tsx
@@ -83,10 +83,13 @@ export default function IngredientList({
         <ListSubheader>Ingredients</ListSubheader>
         <Paper square>
           {sortIngredients(scaledIngredients).map((ingredient) => {
-            let href = getIngredientUrl(ingredient);
-            if (ingredient.type === 'juice') {
-              href += `?${new URLSearchParams({ juiceAmount: String(ingredient.quantity.amount) })}`;
-            }
+            const href =
+              ingredient.type === 'juice'
+                ? {
+                    pathname: getIngredientUrl(ingredient),
+                    query: { juiceAmount: String(ingredient.quantity.amount) },
+                  }
+                : getIngredientUrl(ingredient);
 
             return (
               <Link key={ingredient.slug} href={href}>

--- a/src/components/LinkList/index.tsx
+++ b/src/components/LinkList/index.tsx
@@ -1,3 +1,4 @@
+import type { Route } from 'next';
 import ChevronRight from '@mui/icons-material/ChevronRight';
 import { List, ListItem, ListItemText, ListSubheader, Paper, Stack } from '@mui/material';
 import Link from 'next/link';
@@ -8,7 +9,7 @@ export function LinkListItem({
   secondary,
   tertiary,
 }: {
-  href?: string;
+  href?: Route;
   primary: React.ReactNode;
   secondary?: React.ReactNode;
   tertiary?: React.ReactNode;

--- a/src/modules/url.ts
+++ b/src/modules/url.ts
@@ -1,50 +1,51 @@
+import type { Route } from 'next';
 import slugify from '@sindresorhus/slugify';
 import type { RecipeIngredient } from '@/types/Ingredient';
 import type { Recipe } from '@/types/Recipe';
 import type { Source } from '@/types/Source';
 
-export function getRecipeUrl(recipe: Recipe) {
-  return `/recipes/${recipe.source.type}/${recipe.source.slug}/${recipe.slug}`;
+export function getRecipeUrl(recipe: Recipe): Route {
+  return `/recipes/${recipe.source.type}/${recipe.source.slug}/${recipe.slug}` as Route;
 }
 
-export function getCategoryUrl(category: { slug: string }) {
-  return `/category/${category.slug}`;
+export function getCategoryUrl(category: { slug: string }): Route {
+  return `/category/${category.slug}` as Route;
 }
 
-export function getIngredientUrl(ingredient: Omit<RecipeIngredient, 'quantity'>) {
+export function getIngredientUrl(ingredient: Omit<RecipeIngredient, 'quantity'>): Route {
   if (ingredient.type === 'category') return getCategoryUrl(ingredient);
 
-  return `/ingredient/${ingredient.type}/${ingredient.slug}`;
+  return `/ingredient/${ingredient.type}/${ingredient.slug}` as Route;
 }
 
-export function getSourceUrl(source: Source) {
-  return `/source/${source.type}/${source.slug}`;
+export function getSourceUrl(source: Source): Route {
+  return `/source/${source.type}/${source.slug}` as Route;
 }
 
-export function getRecipeListUrl() {
+export function getRecipeListUrl(): Route {
   return '/list/recipes';
 }
 
-export function getBottleListUrl() {
+export function getBottleListUrl(): Route {
   return '/list/bottles';
 }
 
-export function getIngredientListUrl() {
+export function getIngredientListUrl(): Route {
   return '/list/ingredients';
 }
 
-export function getAuthorListUrl() {
+export function getAuthorListUrl(): Route {
   return '/list/authors';
 }
 
-export function getBarListUrl() {
+export function getBarListUrl(): Route {
   return '/list/bars';
 }
 
-export function getAuthorRecipesUrl(author: string) {
-  return `/list/authors/${slugify(author)}`;
+export function getAuthorRecipesUrl(author: string): Route {
+  return `/list/authors/${slugify(author)}` as Route;
 }
 
-export function getBarRecipesUrl(bar: { name: string; location?: string }) {
-  return `/list/bars/${slugify(`${bar.name} ${bar.location ?? ''}`)}`;
+export function getBarRecipesUrl(bar: { name: string; location?: string }): Route {
+  return `/list/bars/${slugify(`${bar.name} ${bar.location ?? ''}`)}` as Route;
 }


### PR DESCRIPTION
## Summary

- Enable Next.js `typedRoutes` configuration for compile-time route validation
- URL builder functions in `src/modules/url.ts` now return `Route` type
- Components use Next.js href objects for query parameters where possible
- `LinkListItem` and theme `LinkProps` updated for typed routes compatibility

## Test plan

- [x] `yarn lint` passes with route types generated
- [x] All 250 tests pass
- [x] Invalid routes would now produce TypeScript errors at build time