### PR TITLE
feat: add youtube skill for fetching video metadata

### DIFF
--- a/.claude/skills/youtube/SKILL.md
+++ b/.claude/skills/youtube/SKILL.md
@@ -17,6 +17,7 @@ yt-dlp --skip-download --dump-json "VIDEO_URL"
 ```
 
 This returns JSON with:
+
 - `title` - Video title
 - `description` - Full description (often contains recipes, timestamps, links)
 - `channel` - Channel name (useful for source attribution)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@ Start by reading @README.md
 # Environment
 
 - Module: `esm`. Use ES modules (import/export) syntax, not CommonJS (require)
-- Package manager: `yarn`.
+- Package manager: `yarn`. Run `yarn install` when starting work from a new worktree.
 - Node version: >=24. This means scripts should always be `*.ts` files and simply executed with `node file.ts` with the built-in type-stripping support. This also means you must use modern JavaScript features, like `toSorted` instead of `sort`, etc.
 - Framework: Next.js.
 


### PR DESCRIPTION
## Summary

- Adds a new Claude Code skill for fetching YouTube video metadata using `yt-dlp`
- Skill auto-triggers when user provides a YouTube URL or asks for video details
- Enables extracting video descriptions which often contain recipe details

## Test plan

- [ ] Verify skill is recognized by Claude Code
- [ ] Test with a YouTube URL to confirm yt-dlp commands work