### PR TITLE
feat: add 5 new Make and Drink recipes

### DIFF
--- a/src/data/categories/hazelnut-liqueur.json
+++ b/src/data/categories/hazelnut-liqueur.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../schemas/category.schema.json",
+  "name": "Hazelnut liqueur",
+  "categoryType": "liqueur"
+}

--- a/src/data/ingredients/liqueur/frangelico.json
+++ b/src/data/ingredients/liqueur/frangelico.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Frangelico",
+  "type": "liqueur",
+  "categories": ["Hazelnut liqueur"]
+}

--- a/src/data/ingredients/spirit/havana-club-cuban-smoky.json
+++ b/src/data/ingredients/spirit/havana-club-cuban-smoky.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Havana Club Cuban Smoky",
+  "type": "spirit",
+  "categories": ["Column still aged rum"]
+}

--- a/src/data/ingredients/spirit/havana-club-profundo.json
+++ b/src/data/ingredients/spirit/havana-club-profundo.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Havana Club Profundo",
+  "type": "spirit",
+  "categories": ["Column still aged rum"]
+}

--- a/src/data/ingredients/spirit/jameson.json
+++ b/src/data/ingredients/spirit/jameson.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Jameson",
+  "type": "spirit",
+  "categories": ["Whiskey (Irish)"]
+}

--- a/src/data/recipes/youtube-channel/make-and-drink/angelico-martini.json
+++ b/src/data/recipes/youtube-channel/make-and-drink/angelico-martini.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Angelico Martini",
+  "ingredients": [
+    {
+      "name": "Angostura bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 2,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Frangelico",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Vanilla syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "espresso",
+      "type": "other",
+      "technique": {
+        "technique": "temperature",
+        "method": "chilled"
+      },
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Vodka",
+      "type": "category",
+      "quantity": {
+        "amount": 2,
+        "unit": "oz"
+      }
+    }
+  ],
+  "preparation": "shaken",
+  "served_on": "up",
+  "glassware": "coupe",
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "jOtodT0sKsI",
+      "start": 517
+    }
+  ]
+}

--- a/src/data/recipes/youtube-channel/make-and-drink/frangelico-negroni.json
+++ b/src/data/recipes/youtube-channel/make-and-drink/frangelico-negroni.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Frangelico Negroni",
+  "ingredients": [
+    {
+      "name": "Frangelico",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Campari",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Sweet vermouth",
+      "type": "category",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Appleton 12",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "jOtodT0sKsI",
+      "start": 338
+    }
+  ]
+}

--- a/src/data/recipes/youtube-channel/make-and-drink/iba-tiki.json
+++ b/src/data/recipes/youtube-channel/make-and-drink/iba-tiki.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "IBA Tiki",
+  "ingredients": [
+    {
+      "name": "Pineapple Juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 3,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lime Juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Passion fruit purée",
+      "type": "puree",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Amaretto",
+      "type": "category",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Frangelico",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Luxardo Maraschino Liqueur",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 5,
+        "unit": "drop"
+      }
+    },
+    {
+      "name": "Havana Club Profundo",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Havana Club Cuban Smoky",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "preparation": "shaken",
+  "served_on": "crushed ice",
+  "glassware": "tiki",
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "jOtodT0sKsI",
+      "start": 761
+    }
+  ]
+}

--- a/src/data/recipes/youtube-channel/make-and-drink/rum-and-fruit.json
+++ b/src/data/recipes/youtube-channel/make-and-drink/rum-and-fruit.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Rum & Fruit",
+  "ingredients": [
+    {
+      "name": "Lime Juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Passion fruit syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.33,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Bénédictine",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Rum",
+      "type": "category",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "preparation": "shaken",
+  "served_on": "up",
+  "glassware": "coupe",
+  "attributions": [
+    {
+      "source": "Ron Rico Official Mixtros Guide",
+      "relation": "book"
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "G8149Ha_04c",
+      "start": 168
+    }
+  ]
+}

--- a/src/data/recipes/youtube-channel/make-and-drink/spirit-of-portland.json
+++ b/src/data/recipes/youtube-channel/make-and-drink/spirit-of-portland.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Spirit of Portland",
+  "ingredients": [
+    {
+      "name": "Pineapple Juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lime Juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Simple syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Frangelico",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Jameson",
+      "type": "spirit",
+      "quantity": {
+        "amount": 2,
+        "unit": "oz"
+      }
+    }
+  ],
+  "preparation": "shaken",
+  "served_on": "crushed ice",
+  "glassware": "old fashioned",
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "jOtodT0sKsI",
+      "start": 124
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add 5 new cocktail recipes from Make and Drink YouTube channel
- Add supporting ingredients (Frangelico, Jameson, Havana Club variants)
- Add Hazelnut liqueur category

## New Recipes
From [4 Frangelico Cocktails](https://www.youtube.com/watch?v=jOtodT0sKsI):
- **Spirit of Portland** - Irish whiskey with pineapple, lime, and Frangelico
- **Frangelico Negroni** - Rum-based negroni variation with Frangelico
- **Angelico Martini** - Espresso martini style with Frangelico and vanilla
- **IBA Tiki** - Tropical tiki with Havana Club rums and passion fruit

From [Rum & Fruit](https://www.youtube.com/watch?v=G8149Ha_04c):
- **Rum & Fruit** - Historic 1940 cocktail with Bénédictine and passion fruit

## Test plan
- [x] `yarn check-data` passes