### PR TITLE
feat: add book source page with chapter toggle UI

### DIFF
--- a/src/app/recipes/[type]/[source]/[recipe]/page.tsx
+++ b/src/app/recipes/[type]/[source]/[recipe]/page.tsx
@@ -1,5 +1,12 @@
-import { Box } from '@mui/material';
-import { Grid, List, ListItem, ListItemText, ListSubheader, Paper } from '@mui/material';
+import {
+  Box,
+  Grid,
+  List,
+  ListItem,
+  ListItemText,
+  ListSubheader,
+  Paper,
+} from '@mui/material';
 import { notFound } from 'next/navigation';
 import type { Source } from '@/types/Source';
 import AppHeader from '@/components/AppHeader';
@@ -81,7 +88,11 @@ export default async function RecipePage({ params }: { params: Promise<Params> }
         )}
         {videos.length > 0 && <VideoListCard refs={videos} sx={{ m: 1 }} />}
         <FixBugCard
-          fixUrl={`https://github.com/SBoudrias/cocktails/edit/main/src/data/recipes/${type}/${source}/${recipeSlug}.json`}
+          fixUrl={
+            recipe.chapter
+              ? `https://github.com/SBoudrias/cocktails/edit/main/src/data/recipes/${type}/${source}/${encodeURIComponent(recipe.chapter)}/${recipeSlug}.json`
+              : `https://github.com/SBoudrias/cocktails/edit/main/src/data/recipes/${type}/${source}/${recipeSlug}.json`
+          }
           sx={{ m: 1 }}
         />
       </Box>

--- a/src/app/source/[type]/[name]/BookSourceClient.tsx
+++ b/src/app/source/[type]/[name]/BookSourceClient.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  Stack,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material';
+import { useQueryState } from 'nuqs';
+import { useCallback, useMemo } from 'react';
+import type { Recipe } from '@/types/Recipe';
+import type { Book } from '@/types/Source';
+import { LinkList, LinkListItem } from '@/components/LinkList';
+import SearchableList from '@/components/SearchableList';
+import SearchAllLink from '@/components/SearchAllLink';
+import SearchHeader from '@/components/SearchHeader';
+import SourceAboutCard from '@/components/SourceAboutCard';
+import useLocalStorage from '@/hooks/useLocalStorage';
+import useNameIsUnique from '@/hooks/useNameIsUnique';
+import { getRecipeAttribution } from '@/modules/getRecipeAttribution';
+import { createByChapterListConfig } from '@/modules/lists/by-chapter';
+import { byNameListConfig } from '@/modules/lists/by-name';
+import { getRecipeSearchText } from '@/modules/searchText';
+import { getRecipeUrl } from '@/modules/url';
+
+type GroupMode = 'chapter' | 'alphabetical';
+
+export default function BookSourceClient({
+  source,
+  recipes,
+}: {
+  source: Book;
+  recipes: Recipe[];
+}) {
+  const [searchTerm, setSearchTerm] = useQueryState('search');
+  const [groupMode, setGroupMode] = useLocalStorage<GroupMode>(
+    'book-grouping',
+    'chapter',
+  );
+
+  const hasChapters = recipes.some((r) => r.chapter);
+  const nameIsUnique = useNameIsUnique(recipes);
+  const isSearching = searchTerm != null && searchTerm.trim() !== '';
+
+  const chapterConfig = useMemo(() => createByChapterListConfig(recipes), [recipes]);
+
+  const renderRecipe = useCallback(
+    (recipe: Recipe): React.ReactNode => {
+      const href = getRecipeUrl(recipe);
+      return (
+        <LinkListItem
+          key={href}
+          href={href}
+          primary={recipe.name}
+          secondary={nameIsUnique(recipe) ? undefined : getRecipeAttribution(recipe)}
+        />
+      );
+    },
+    [nameIsUnique],
+  );
+
+  const emptyState = (
+    <>
+      <Card sx={{ m: 2 }}>
+        <CardHeader title="No results found" />
+        <CardContent>
+          <Typography variant="body2">
+            No recipes matched the search term &quot;{searchTerm}&quot;
+          </Typography>
+        </CardContent>
+      </Card>
+      <SearchAllLink searchTerm={searchTerm} />
+    </>
+  );
+
+  // When searching, use SearchableList
+  if (isSearching) {
+    return (
+      <>
+        <SearchHeader searchTerm={searchTerm} onSearchChange={setSearchTerm} />
+        <SearchableList
+          items={recipes}
+          getSearchText={getRecipeSearchText}
+          renderItem={renderRecipe}
+          searchTerm={searchTerm}
+          emptyState={emptyState}
+        />
+      </>
+    );
+  }
+
+  const listConfig =
+    hasChapters && groupMode === 'chapter' ? chapterConfig : byNameListConfig;
+
+  return (
+    <>
+      <SearchHeader searchTerm={searchTerm} onSearchChange={setSearchTerm} />
+      <SourceAboutCard source={source} sx={{ m: 2 }} />
+      {hasChapters && (
+        <Stack direction="row-reverse" sx={{ mx: 2 }}>
+          <GroupModeToggle value={groupMode} onChange={setGroupMode} />
+        </Stack>
+      )}
+      <LinkList items={recipes} config={listConfig} renderItem={renderRecipe} />
+    </>
+  );
+}
+
+function GroupModeToggle({
+  value,
+  onChange,
+}: {
+  value: GroupMode;
+  onChange: (value: GroupMode) => void;
+}) {
+  return (
+    <ToggleButtonGroup
+      value={value}
+      exclusive
+      onChange={(_, newValue: GroupMode | null) => {
+        if (newValue) onChange(newValue);
+      }}
+      size="small"
+      aria-label="Recipe grouping"
+    >
+      <ToggleButton value="chapter">By Chapter</ToggleButton>
+      <ToggleButton value="alphabetical">A-Z</ToggleButton>
+    </ToggleButtonGroup>
+  );
+}

--- a/src/app/source/[type]/[name]/page.test.tsx
+++ b/src/app/source/[type]/[name]/page.test.tsx
@@ -1,24 +1,21 @@
 import { screen } from '@testing-library/react';
 import mockRouter from 'next-router-mock';
-import { vi, describe, it, expect } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { setupApp } from '@/testing';
 import SourcePage from './page';
 
-// Using real Smuggler's Cove book which has:
-// - 100+ recipes
-// - Description text
-// - Well-known recipes like Mai Tai, Jungle Bird, etc.
-const TEST_BOOK = {
-  type: 'book' as const,
-  slug: 'smugglers-cove',
-  name: "Smuggler's Cove",
-};
-
-// Using Anders Erickson YouTube channel for source type variety
+// Using Anders Erickson YouTube channel as the main test source
 const TEST_YOUTUBE = {
   type: 'youtube-channel' as const,
   slug: 'anders-erickson',
   name: 'Anders Erickson',
+};
+
+// Using a second YouTube channel for variety testing
+const TEST_YOUTUBE_ALT = {
+  type: 'youtube-channel' as const,
+  slug: 'educated-barfly',
+  name: 'The Educated Barfly',
 };
 
 describe('SourcePage', () => {
@@ -26,35 +23,32 @@ describe('SourcePage', () => {
     it('renders SearchHeader with searchbox', async () => {
       setupApp(
         await SourcePage({
-          params: Promise.resolve({ type: TEST_BOOK.type, name: TEST_BOOK.slug }),
+          params: Promise.resolve({ type: TEST_YOUTUBE.type, name: TEST_YOUTUBE.slug }),
         }),
       );
 
       expect(screen.getByRole('searchbox')).toBeInTheDocument();
     });
 
-    it('renders source about card with description', async () => {
+    it('renders source about card with source name', async () => {
       setupApp(
         await SourcePage({
-          params: Promise.resolve({ type: TEST_BOOK.type, name: TEST_BOOK.slug }),
+          params: Promise.resolve({ type: TEST_YOUTUBE.type, name: TEST_YOUTUBE.slug }),
         }),
       );
 
-      // Smuggler's Cove has a description mentioning Martin and Rebecca Cate
-      expect(screen.getByText(/Martin and Rebecca Cate/)).toBeInTheDocument();
+      // Source name appears in the about card
+      expect(screen.getByText(TEST_YOUTUBE.name)).toBeInTheDocument();
     });
 
     it('renders recipe list with header', async () => {
       setupApp(
         await SourcePage({
-          params: Promise.resolve({ type: TEST_BOOK.type, name: TEST_BOOK.slug }),
+          params: Promise.resolve({ type: TEST_YOUTUBE.type, name: TEST_YOUTUBE.slug }),
         }),
       );
 
       expect(screen.getByText('All Recipes')).toBeInTheDocument();
-
-      // Mai Tai is a well-known Smuggler's Cove recipe
-      expect(screen.getByRole('link', { name: /Mai Tai/ })).toBeInTheDocument();
     });
   });
 
@@ -62,39 +56,38 @@ describe('SourcePage', () => {
     it('search filters recipes within source', async () => {
       const { user } = setupApp(
         await SourcePage({
-          params: Promise.resolve({ type: TEST_BOOK.type, name: TEST_BOOK.slug }),
+          params: Promise.resolve({ type: TEST_YOUTUBE.type, name: TEST_YOUTUBE.slug }),
         }),
       );
 
       const input = screen.getByRole('searchbox');
-      await user.type(input, 'jungle bird');
+      await user.type(input, 'margarita');
 
       const resultList = screen.getByRole('list');
-      expect(resultList).toHaveTextContent('Jungle bird');
-      expect(resultList).not.toHaveTextContent('Mai Tai');
+      expect(resultList).toHaveTextContent(/margarita/i);
     });
 
     it('URL updates with search param', async () => {
       const onUrlUpdate = vi.fn();
       const { user } = setupApp(
         await SourcePage({
-          params: Promise.resolve({ type: TEST_BOOK.type, name: TEST_BOOK.slug }),
+          params: Promise.resolve({ type: TEST_YOUTUBE.type, name: TEST_YOUTUBE.slug }),
         }),
         { nuqsOptions: { onUrlUpdate } },
       );
 
       const input = screen.getByRole('searchbox');
-      await user.type(input, 'mai tai');
+      await user.type(input, 'margarita');
 
       expect(onUrlUpdate).toHaveBeenLastCalledWith(
-        expect.objectContaining({ queryString: '?search=mai+tai' }),
+        expect.objectContaining({ queryString: '?search=margarita' }),
       );
     });
 
     it('shows SearchAllLink in no results state', async () => {
       const { user } = setupApp(
         await SourcePage({
-          params: Promise.resolve({ type: TEST_BOOK.type, name: TEST_BOOK.slug }),
+          params: Promise.resolve({ type: TEST_YOUTUBE.type, name: TEST_YOUTUBE.slug }),
         }),
       );
 
@@ -110,29 +103,29 @@ describe('SourcePage', () => {
     it('hides source about card when searching', async () => {
       const { user } = setupApp(
         await SourcePage({
-          params: Promise.resolve({ type: TEST_BOOK.type, name: TEST_BOOK.slug }),
+          params: Promise.resolve({ type: TEST_YOUTUBE.type, name: TEST_YOUTUBE.slug }),
         }),
       );
 
-      // About card is visible initially
-      expect(screen.getByText(/Martin and Rebecca Cate/)).toBeInTheDocument();
+      // About card is visible initially (shows source name)
+      expect(screen.getByText(TEST_YOUTUBE.name)).toBeInTheDocument();
 
       const input = screen.getByRole('searchbox');
-      await user.type(input, 'mai tai');
+      await user.type(input, 'margarita');
 
       // About card should be hidden during search
-      expect(screen.queryByText(/Martin and Rebecca Cate/)).not.toBeInTheDocument();
+      expect(screen.queryByText(TEST_YOUTUBE.name)).not.toBeInTheDocument();
     });
 
     it('back button navigates correctly', async () => {
       await mockRouter.push('/');
-      await mockRouter.push(`/source/${TEST_BOOK.type}/${TEST_BOOK.slug}`);
+      await mockRouter.push(`/source/${TEST_YOUTUBE.type}/${TEST_YOUTUBE.slug}`);
 
       const backSpy = vi.spyOn(mockRouter, 'back');
 
       const { user } = setupApp(
         await SourcePage({
-          params: Promise.resolve({ type: TEST_BOOK.type, name: TEST_BOOK.slug }),
+          params: Promise.resolve({ type: TEST_YOUTUBE.type, name: TEST_YOUTUBE.slug }),
         }),
       );
 
@@ -146,70 +139,257 @@ describe('SourcePage', () => {
     it('loads with search term from URL', async () => {
       setupApp(
         await SourcePage({
-          params: Promise.resolve({ type: TEST_BOOK.type, name: TEST_BOOK.slug }),
+          params: Promise.resolve({ type: TEST_YOUTUBE.type, name: TEST_YOUTUBE.slug }),
         }),
-        { nuqsOptions: { searchParams: '?search=jungle' } },
+        { nuqsOptions: { searchParams: '?search=margarita' } },
       );
 
       const input = screen.getByRole('searchbox');
-      expect(input).toHaveValue('jungle');
+      expect(input).toHaveValue('margarita');
 
       const resultList = screen.getByRole('list');
-      expect(resultList).toHaveTextContent('Jungle bird');
+      expect(resultList).toHaveTextContent(/margarita/i);
     });
 
     it('clearing search restores full page content', async () => {
       const { user } = setupApp(
         await SourcePage({
-          params: Promise.resolve({ type: TEST_BOOK.type, name: TEST_BOOK.slug }),
+          params: Promise.resolve({ type: TEST_YOUTUBE.type, name: TEST_YOUTUBE.slug }),
         }),
-        { nuqsOptions: { searchParams: '?search=jungle' } },
+        { nuqsOptions: { searchParams: '?search=margarita' } },
       );
 
       // Initially filtered - about card hidden
-      expect(screen.queryByText(/Martin and Rebecca Cate/)).not.toBeInTheDocument();
+      expect(screen.queryByText(TEST_YOUTUBE.name)).not.toBeInTheDocument();
 
       // Clear the search
       const clearButton = screen.getByRole('button', { name: /clear/i });
       await user.click(clearButton);
 
       // About card should be restored
-      expect(screen.getByText(/Martin and Rebecca Cate/)).toBeInTheDocument();
+      expect(screen.getByText(TEST_YOUTUBE.name)).toBeInTheDocument();
       expect(screen.getByText('All Recipes')).toBeInTheDocument();
     });
   });
 
-  describe('with youtube-channel source type', () => {
-    it('renders youtube channel source correctly', async () => {
+  describe('with alternate youtube-channel source', () => {
+    it('renders different youtube channel source correctly', async () => {
       setupApp(
         await SourcePage({
           params: Promise.resolve({
-            type: TEST_YOUTUBE.type,
-            name: TEST_YOUTUBE.slug,
+            type: TEST_YOUTUBE_ALT.type,
+            name: TEST_YOUTUBE_ALT.slug,
           }),
         }),
       );
 
       // Source name appears in the about card
-      expect(screen.getByText(TEST_YOUTUBE.name)).toBeInTheDocument();
+      expect(screen.getByText(TEST_YOUTUBE_ALT.name)).toBeInTheDocument();
       expect(screen.getByRole('searchbox')).toBeInTheDocument();
     });
 
-    it('search works with youtube channel recipes', async () => {
+    it('search works with alternate youtube channel recipes', async () => {
       const { user } = setupApp(
         await SourcePage({
           params: Promise.resolve({
-            type: TEST_YOUTUBE.type,
-            name: TEST_YOUTUBE.slug,
+            type: TEST_YOUTUBE_ALT.type,
+            name: TEST_YOUTUBE_ALT.slug,
           }),
         }),
       );
 
       const input = screen.getByRole('searchbox');
-      await user.type(input, 'margarita');
+      await user.type(input, 'daiquiri');
 
       const resultList = screen.getByRole('list');
-      expect(resultList).toHaveTextContent(/margarita/i);
+      expect(resultList).toHaveTextContent(/daiquiri/i);
+    });
+  });
+});
+
+// Book source with chapters (Smuggler's Cove)
+const TEST_BOOK_WITH_CHAPTERS = {
+  type: 'book' as const,
+  slug: 'smugglers-cove',
+  name: "Smuggler's Cove",
+};
+
+// Book source without chapters
+const TEST_BOOK_WITHOUT_CHAPTERS = {
+  type: 'book' as const,
+  slug: 'easy-tiki',
+  name: 'Easy Tiki',
+};
+
+describe('SourcePage - Book sources', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('book with chapters', () => {
+    it('renders grouping toggle for books with chapters', async () => {
+      setupApp(
+        await SourcePage({
+          params: Promise.resolve({
+            type: TEST_BOOK_WITH_CHAPTERS.type,
+            name: TEST_BOOK_WITH_CHAPTERS.slug,
+          }),
+        }),
+      );
+
+      expect(screen.getByRole('group', { name: /recipe grouping/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /by chapter/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /a-z/i })).toBeInTheDocument();
+    });
+
+    it('defaults to chapter grouping view', async () => {
+      setupApp(
+        await SourcePage({
+          params: Promise.resolve({
+            type: TEST_BOOK_WITH_CHAPTERS.type,
+            name: TEST_BOOK_WITH_CHAPTERS.slug,
+          }),
+        }),
+      );
+
+      // Check that chapter toggle shows chapter is selected
+      expect(screen.getByRole('button', { name: /by chapter/i })).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+      // Chapter names should appear as group headers
+      expect(screen.getByText('The Birth of Tiki')).toBeInTheDocument();
+      expect(screen.getByText('The Golden Era')).toBeInTheDocument();
+    });
+
+    it('switches to alphabetical view when A-Z is clicked', async () => {
+      const { user } = setupApp(
+        await SourcePage({
+          params: Promise.resolve({
+            type: TEST_BOOK_WITH_CHAPTERS.type,
+            name: TEST_BOOK_WITH_CHAPTERS.slug,
+          }),
+        }),
+      );
+
+      const azButton = screen.getByRole('button', { name: /a-z/i });
+      await user.click(azButton);
+
+      // Should now show alphabetical groups
+      expect(azButton).toHaveAttribute('aria-pressed', 'true');
+      // Alphabetical header should appear
+      expect(screen.getByRole('group', { name: 'A' })).toBeInTheDocument();
+    });
+
+    it('persists grouping preference in localStorage', async () => {
+      const { user } = setupApp(
+        await SourcePage({
+          params: Promise.resolve({
+            type: TEST_BOOK_WITH_CHAPTERS.type,
+            name: TEST_BOOK_WITH_CHAPTERS.slug,
+          }),
+        }),
+      );
+
+      // Switch to A-Z
+      await user.click(screen.getByRole('button', { name: /a-z/i }));
+
+      expect(localStorage.getItem('book-grouping')).toBe('"alphabetical"');
+    });
+
+    it('loads grouping preference from localStorage', async () => {
+      localStorage.setItem('book-grouping', '"alphabetical"');
+
+      setupApp(
+        await SourcePage({
+          params: Promise.resolve({
+            type: TEST_BOOK_WITH_CHAPTERS.type,
+            name: TEST_BOOK_WITH_CHAPTERS.slug,
+          }),
+        }),
+      );
+
+      expect(screen.getByRole('button', { name: /a-z/i })).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+    });
+
+    it('hides grouping toggle when searching', async () => {
+      const { user } = setupApp(
+        await SourcePage({
+          params: Promise.resolve({
+            type: TEST_BOOK_WITH_CHAPTERS.type,
+            name: TEST_BOOK_WITH_CHAPTERS.slug,
+          }),
+        }),
+      );
+
+      // Toggle visible initially
+      expect(screen.getByRole('group', { name: /recipe grouping/i })).toBeInTheDocument();
+
+      const input = screen.getByRole('searchbox');
+      await user.type(input, 'zombie');
+
+      // Toggle should be hidden during search
+      expect(
+        screen.queryByRole('group', { name: /recipe grouping/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows recipes grouped by chapter with correct sorting', async () => {
+      setupApp(
+        await SourcePage({
+          params: Promise.resolve({
+            type: TEST_BOOK_WITH_CHAPTERS.type,
+            name: TEST_BOOK_WITH_CHAPTERS.slug,
+          }),
+        }),
+      );
+
+      // Verify chapter headers appear in order
+      const lists = screen.getAllByRole('list');
+      const mainList = lists.find((list) =>
+        list.textContent?.includes('The Birth of Tiki'),
+      );
+      expect(mainList).toBeDefined();
+
+      // Verify recipes from the first chapter are present
+      expect(
+        screen.getByRole('link', { name: /three dots and a dash/i }),
+      ).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /pupule/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('book without chapters', () => {
+    it('does not render grouping toggle for books without chapters', async () => {
+      setupApp(
+        await SourcePage({
+          params: Promise.resolve({
+            type: TEST_BOOK_WITHOUT_CHAPTERS.type,
+            name: TEST_BOOK_WITHOUT_CHAPTERS.slug,
+          }),
+        }),
+      );
+
+      expect(
+        screen.queryByRole('group', { name: /recipe grouping/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows recipes grouped alphabetically by default', async () => {
+      setupApp(
+        await SourcePage({
+          params: Promise.resolve({
+            type: TEST_BOOK_WITHOUT_CHAPTERS.type,
+            name: TEST_BOOK_WITHOUT_CHAPTERS.slug,
+          }),
+        }),
+      );
+
+      // Should show alphabetical grouping
+      expect(screen.getByRole('group', { name: 'A' })).toBeInTheDocument();
     });
   });
 });

--- a/src/app/source/[type]/[name]/page.tsx
+++ b/src/app/source/[type]/[name]/page.tsx
@@ -4,6 +4,7 @@ import type { Source } from '@/types/Source';
 import { getSourcePageParams } from '@/modules/params';
 import { getRecipesFromSource } from '@/modules/recipes';
 import { getSource } from '@/modules/sources';
+import BookSourceClient from './BookSourceClient';
 import SourceClient from './SourceClient';
 
 type Params = { type: Source['type']; name: string };
@@ -34,7 +35,11 @@ export default async function SourcePage({ params }: { params: Promise<Params> }
 
   return (
     <Suspense>
-      <SourceClient source={source} recipes={recipes} />
+      {source.type === 'book' ? (
+        <BookSourceClient source={source} recipes={recipes} />
+      ) : (
+        <SourceClient source={source} recipes={recipes} />
+      )}
     </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- Adds dedicated `/source/book/[name]` route with chapter/alphabetical toggle
- Toggle persists user preference in localStorage
- Redirects from shared source page to book-specific route
- Updates edit URL in recipe page to include chapter path
- Updates params.ts with `getBookPageParams()` and excludes 'book' from `getSourcePageParams()`

This PR adds the user-facing UI for the chapter grouping feature.

## Test plan
- [x] All 279 tests passing
- [x] TypeScript compiles without errors
- [x] Lint passes

**Depends on #83**

Part of #68