### PR TITLE
refactor: optimize React performance patterns

### DIFF
--- a/src/app/ingredient/[type]/[slug]/page.tsx
+++ b/src/app/ingredient/[type]/[slug]/page.tsx
@@ -37,8 +37,10 @@ export default async function IngredientPage({ params }: { params: Promise<Param
   const { type, slug } = await params;
 
   const ingredient = await getIngredient(type, slug);
-  const substitutes = await getSubstitutesForIngredient(ingredient);
-  const relatedRecipes = await getRecipesForIngredient(ingredient);
+  const [substitutes, relatedRecipes] = await Promise.all([
+    getSubstitutesForIngredient(ingredient),
+    getRecipesForIngredient(ingredient),
+  ]);
 
   return (
     <Suspense>

--- a/src/components/IngredientList/index.tsx
+++ b/src/components/IngredientList/index.tsx
@@ -11,7 +11,7 @@ import {
   Toolbar,
 } from '@mui/material';
 import Link from 'next/link';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { Recipe } from '@/types/Recipe';
 import Quantity from '@/components/Quantity';
 import UnitSelector, { type Unit } from '@/components/Quantity/Selector';
@@ -69,13 +69,17 @@ export default function IngredientList({
   const scaleFactor = calculateScaleFactor(defaultServings, servings);
 
   // Scale all ingredients at the list level
-  const scaledIngredients = ingredients.map((ingredient) => ({
-    ...ingredient,
-    quantity:
-      scaleFactor !== 1
-        ? scaleQuantity(ingredient.quantity, scaleFactor)
-        : ingredient.quantity,
-  }));
+  const scaledIngredients = useMemo(
+    () =>
+      ingredients.map((ingredient) => ({
+        ...ingredient,
+        quantity:
+          scaleFactor !== 1
+            ? scaleQuantity(ingredient.quantity, scaleFactor)
+            : ingredient.quantity,
+      })),
+    [ingredients, scaleFactor],
+  );
 
   return (
     <>


### PR DESCRIPTION
## Summary

- Parallelize directory reads in `getAllRecipes()` using `Promise.all()` instead of sequential for-await loops - reduces data loading time as recipe collection grows
- Add `useMemo` to `IngredientList` scaled ingredients to prevent unnecessary child re-renders when unrelated state changes
- Parallelize `getSubstitutesForIngredient` and `getRecipesForIngredient` calls in ingredient page using `Promise.all()` - these fetches are independent and can run concurrently

## Test plan

- [x] All 269 tests pass
- [x] Lint and typecheck pass
- [x] Manual verification: ingredient pages load correctly
- [x] Manual verification: recipe scaling works in IngredientList