### PR TITLE
feat: add search to author and bar recipe pages

### DIFF
--- a/src/app/list/authors/[name]/AuthorRecipesClient.tsx
+++ b/src/app/list/authors/[name]/AuthorRecipesClient.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { Card, CardHeader } from '@mui/material';
+import { useQueryState } from 'nuqs';
+import type { Recipe } from '@/types/Recipe';
+import { LinkList, LinkListItem } from '@/components/LinkList';
+import SearchableList from '@/components/SearchableList';
+import SearchAllLink from '@/components/SearchAllLink';
+import SearchHeader from '@/components/SearchHeader';
+import { getRecipeSearchText } from '@/modules/searchText';
+import { getRecipeUrl } from '@/modules/url';
+
+function renderRecipe(recipe: Recipe, authorName: string) {
+  // Get the attribution if the recipe was adapted by someone else
+  const adaptedBy = recipe.attributions.find(
+    (attribution) =>
+      attribution.relation === 'adapted by' && attribution.source !== authorName,
+  );
+
+  const href = getRecipeUrl(recipe);
+  return (
+    <LinkListItem
+      key={href}
+      href={href}
+      primary={recipe.name}
+      secondary={adaptedBy ? `Adapted by ${adaptedBy.source}` : undefined}
+    />
+  );
+}
+
+export default function AuthorRecipesClient({
+  authorName,
+  recipes,
+}: {
+  authorName: string;
+  recipes: Recipe[];
+}) {
+  const [searchTerm, setSearchTerm] = useQueryState('search');
+  const isSearching = searchTerm != null && searchTerm.trim() !== '';
+
+  const emptyState = (
+    <>
+      <Card sx={{ m: 2 }}>
+        <CardHeader title="No results found" />
+      </Card>
+      <SearchAllLink searchTerm={searchTerm} />
+    </>
+  );
+
+  const renderItem = (recipe: Recipe) => renderRecipe(recipe, authorName);
+
+  return (
+    <>
+      <SearchHeader
+        title={`Recipes by ${authorName}`}
+        searchTerm={searchTerm}
+        onSearchChange={setSearchTerm}
+      />
+      {isSearching ? (
+        <SearchableList
+          items={recipes}
+          getSearchText={getRecipeSearchText}
+          renderItem={renderItem}
+          searchTerm={searchTerm}
+          emptyState={emptyState}
+        />
+      ) : (
+        <LinkList header="All Recipes" items={recipes} renderItem={renderItem} />
+      )}
+    </>
+  );
+}

--- a/src/app/list/authors/[name]/page.tsx
+++ b/src/app/list/authors/[name]/page.tsx
@@ -1,14 +1,10 @@
 import type { Metadata } from 'next';
-import { ChevronRight } from '@mui/icons-material';
-import { List, ListItem, ListItemText, Paper } from '@mui/material';
 import slugify from '@sindresorhus/slugify';
-import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
 import type { Recipe } from '@/types/Recipe';
-import AppHeader from '@/components/AppHeader';
 import { getAllRecipes } from '@/modules/recipes';
-import { getRecipeUrl } from '@/modules/url';
+import AuthorRecipesClient from './AuthorRecipesClient';
 
 // Helper function to find the actual author name from the slug
 function findAuthorNameFromSlug(slug: string, recipes: Recipe[]): string | null {
@@ -90,30 +86,7 @@ export default async function AuthorRecipesPage({ params }: Props) {
 
   return (
     <Suspense>
-      <AppHeader title={`Recipes by ${authorName}`} />
-      <List sx={{ mt: 2 }}>
-        <Paper square>
-          {authorRecipes.map((recipe) => {
-            // Get the attribution if the recipe was adapted by someone else
-            const adaptedBy = recipe.attributions.find(
-              (attribution) =>
-                attribution.relation === 'adapted by' &&
-                attribution.source !== authorName,
-            );
-
-            return (
-              <Link href={getRecipeUrl(recipe)} key={recipe.slug}>
-                <ListItem divider secondaryAction={<ChevronRight />}>
-                  <ListItemText
-                    primary={recipe.name}
-                    secondary={adaptedBy ? `Adapted by ${adaptedBy.source}` : undefined}
-                  />
-                </ListItem>
-              </Link>
-            );
-          })}
-        </Paper>
-      </List>
+      <AuthorRecipesClient authorName={authorName} recipes={authorRecipes} />
     </Suspense>
   );
 }

--- a/src/app/list/bars/[name]/BarRecipesClient.tsx
+++ b/src/app/list/bars/[name]/BarRecipesClient.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { Card, CardHeader } from '@mui/material';
+import { useQueryState } from 'nuqs';
+import type { Recipe } from '@/types/Recipe';
+import { LinkList, LinkListItem } from '@/components/LinkList';
+import SearchableList from '@/components/SearchableList';
+import SearchAllLink from '@/components/SearchAllLink';
+import SearchHeader from '@/components/SearchHeader';
+import { getRecipeSearchText } from '@/modules/searchText';
+import { getRecipeUrl } from '@/modules/url';
+
+function renderRecipe(recipe: Recipe) {
+  const href = getRecipeUrl(recipe);
+  return <LinkListItem key={href} href={href} primary={recipe.name} />;
+}
+
+export default function BarRecipesClient({
+  barName,
+  recipes,
+}: {
+  barName: string;
+  recipes: Recipe[];
+}) {
+  const [searchTerm, setSearchTerm] = useQueryState('search');
+  const isSearching = searchTerm != null && searchTerm.trim() !== '';
+
+  const emptyState = (
+    <>
+      <Card sx={{ m: 2 }}>
+        <CardHeader title="No results found" />
+      </Card>
+      <SearchAllLink searchTerm={searchTerm} />
+    </>
+  );
+
+  return (
+    <>
+      <SearchHeader
+        title={`Recipes from ${barName}`}
+        searchTerm={searchTerm}
+        onSearchChange={setSearchTerm}
+      />
+      {isSearching ? (
+        <SearchableList
+          items={recipes}
+          getSearchText={getRecipeSearchText}
+          renderItem={renderRecipe}
+          searchTerm={searchTerm}
+          emptyState={emptyState}
+        />
+      ) : (
+        <LinkList header="All Recipes" items={recipes} renderItem={renderRecipe} />
+      )}
+    </>
+  );
+}

--- a/src/app/list/bars/[name]/page.tsx
+++ b/src/app/list/bars/[name]/page.tsx
@@ -1,14 +1,10 @@
 import type { Metadata } from 'next';
-import { ChevronRight } from '@mui/icons-material';
-import { List, ListItem, ListItemText, Paper } from '@mui/material';
 import slugify from '@sindresorhus/slugify';
-import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
 import type { Recipe } from '@/types/Recipe';
-import AppHeader from '@/components/AppHeader';
 import { getAllRecipes } from '@/modules/recipes';
-import { getRecipeUrl } from '@/modules/url';
+import BarRecipesClient from './BarRecipesClient';
 
 // Helper function to find the actual bar name from the slug
 function findBarNameFromSlug(
@@ -96,18 +92,7 @@ export default async function BarRecipesPage({ params }: Props) {
 
   return (
     <Suspense>
-      <AppHeader title={`Recipes from ${formatBarName(bar)}`} />
-      <List sx={{ mt: 2 }}>
-        <Paper square>
-          {barRecipes.map((recipe) => (
-            <Link href={getRecipeUrl(recipe)} key={recipe.slug}>
-              <ListItem divider secondaryAction={<ChevronRight />}>
-                <ListItemText primary={recipe.name} />
-              </ListItem>
-            </Link>
-          ))}
-        </Paper>
-      </List>
+      <BarRecipesClient barName={formatBarName(bar)} recipes={barRecipes} />
     </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- Add search functionality to `/list/authors/[name]` and `/list/bars/[name]` pages
- Both pages now use the same pattern as other searchable list pages (source, category, ingredient)
- Fix ingredient file naming issues (apostrophe slugification)

## Test plan
- [x] Run `yarn vitest --run` - all tests pass
- [x] Run `yarn lint` - no errors
- [ ] Manual testing: verify search works on author recipe pages
- [ ] Manual testing: verify search works on bar recipe pages