### PR TITLE
feat: add PR preview deployments for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,28 +1,19 @@
-name: Deploy Next.js site to Pages
+name: Deploy to GitHub Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ['main']
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: 'pages'
+  group: pages-deploy
   cancel-in-progress: false
 
 jobs:
-  # Build job
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
@@ -31,28 +22,14 @@ jobs:
       - name: Setup Node.js ⚙️ - Cache dependencies ⚡ - Install dependencies 🔧
         uses: ./.github/workflows/setup-node
 
-      - name: Setup Pages ⚙️
-        uses: actions/configure-pages@v4
-        with:
-          static_site_generator: next
-
       - name: Build with Next.js 🏗️
         run: yarn next build
 
-      - name: Upload artifact 📡
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy to gh-pages 🚀
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: ./out
-
-  # Deployment job
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - name: Deploy to GitHub Pages 🚀
-        id: deployment
-        uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./out
+          publish_branch: gh-pages
+          keep_files: false
+          exclude_assets: 'pr-preview'

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,36 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ⚙️ - Cache dependencies ⚡ - Install dependencies 🔧
+        uses: ./.github/workflows/setup-node
+        if: github.event.action != 'closed'
+
+      - name: Build with preview basePath 🏗️
+        if: github.event.action != 'closed'
+        run: yarn next build
+        env:
+          NEXT_PUBLIC_BASE_PATH: /cocktails/pr-preview/pr-${{ github.event.number }}
+
+      - name: Deploy PR Preview 🚀
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./out/
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: auto

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
-  basePath: '/cocktails',
+  basePath: process.env.NEXT_PUBLIC_BASE_PATH || '/cocktails',
   reactStrictMode: true,
   // TODO: enable
   // typedRoutes: true,


### PR DESCRIPTION
## Summary

- Switch from GitHub Actions deployment to branch-based deployment using `peaceiris/actions-gh-pages`
- Add `rossjrw/pr-preview-action` to deploy PR previews to subdirectories
- Make `basePath` configurable via environment variable for different deployment paths

PR previews will be available at:
```
https://sboudrias.github.io/cocktails/pr-preview/pr-[number]/
```

## Manual Setup Required After Merge

1. **Settings → Pages → Source**: Change from "GitHub Actions" to "Deploy from branch" (`gh-pages`, `/ (root)`)
2. **Settings → Actions → General → Workflow permissions**: Select "Read and write permissions"

## How It Works

- Production deploys push to `gh-pages` branch root, excluding the `pr-preview` directory
- PR previews push to `gh-pages` branch under `pr-preview/pr-[number]/`
- When PRs are closed/merged, the preview directory is automatically cleaned up
- A comment with the preview link is posted on each PR

## Test Plan

- [ ] Merge this PR
- [ ] Complete the manual setup steps above
- [ ] Verify production deployment still works
- [ ] Open a test PR and verify preview deploys
- [ ] Close/merge test PR and verify cleanup