### PR TITLE
fix: group numeric names under # in alphabetical lists

### DIFF
--- a/src/modules/lists/by-name.test.ts
+++ b/src/modules/lists/by-name.test.ts
@@ -27,8 +27,9 @@ describe('getNameFirstLetter', () => {
     expect(getNameFirstLetter({ name: 'the storm' })).toBe('S');
   });
 
-  it('returns the first character for names starting with non-letter', () => {
-    expect(getNameFirstLetter({ name: '123 Cocktail' })).toBe('1');
+  it('returns # for names starting with numbers', () => {
+    expect(getNameFirstLetter({ name: '123 Cocktail' })).toBe('#');
+    expect(getNameFirstLetter({ name: '3 Dots and a Dash' })).toBe('#');
   });
 
   it('handles empty string', () => {

--- a/src/modules/lists/by-name.ts
+++ b/src/modules/lists/by-name.ts
@@ -3,10 +3,13 @@ const articleRegExp = /^(the |an |a )?(.+)/i;
 /**
  * Extracts the first letter of a name, skipping leading articles (the, an, a).
  * Used for alphabetical grouping in lists.
+ * Names starting with numbers are grouped under '#'.
  */
 export function getNameFirstLetter<T extends { name: string }>(item: T): string {
   const matches = item.name.match(articleRegExp) ?? [];
-  return matches[2]?.slice(0, 1).toUpperCase() ?? '#';
+  const firstChar = matches[2]?.slice(0, 1).toUpperCase() ?? '#';
+  // Group all numbers under '#'
+  return /\d/.test(firstChar) ? '#' : firstChar;
 }
 
 /**
@@ -24,5 +27,10 @@ export function compareByName<T extends { name: string }>(a: T, b: T) {
 export const byNameListConfig = {
   groupBy: getNameFirstLetter,
   sortItemBy: compareByName,
-  sortHeaderBy: (a: string, b: string) => a.localeCompare(b),
+  sortHeaderBy: (a: string, b: string) => {
+    // '#' always comes first
+    if (a === '#') return -1;
+    if (b === '#') return 1;
+    return a.localeCompare(b);
+  },
 };


### PR DESCRIPTION
## Summary
- Names starting with numbers (e.g., "3 Dots and a Dash", "123 Cocktail") are now grouped under a single `#` header instead of individual digit groups
- The `#` group is sorted to appear first in alphabetical lists

## Test plan
- [x] Updated unit tests for `getNameFirstLetter` to verify numeric names return `#`
- [x] All tests pass (`yarn vitest --run`)
- [x] Lint passes (`yarn lint`)