### PR TITLE
fix: prevent duplicate bars from case inconsistencies

### DIFF
--- a/src/data/recipes/youtube-channel/make-and-drink/rongorongo.json
+++ b/src/data/recipes/youtube-channel/make-and-drink/rongorongo.json
@@ -75,7 +75,7 @@
     },
     {
       "relation": "bar",
-      "source": "Smuggler's cove",
+      "source": "Smuggler's Cove",
       "location": "San Francisco, CA"
     }
   ]


### PR DESCRIPTION
## Summary
- Fix "Smuggler's cove" → "Smuggler's Cove" typo in rongorongo.json that caused the bar to appear twice in the bar list
- Add validation to `check-data` that detects inconsistent bar name casing across recipe files

## Test plan
- [x] `yarn check-data` passes
- [x] `yarn lint` passes
- [x] `yarn vitest --run src/app/list/bars` passes
- [ ] Verify bar list no longer shows duplicate Smuggler's Cove