### PR TITLE
fix: preserve PR previews during main branch deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,10 +26,9 @@ jobs:
         run: yarn next build
 
       - name: Deploy to gh-pages 🚀
-        uses: peaceiris/actions-gh-pages@v4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./out
-          publish_branch: gh-pages
-          keep_files: false
-          exclude_assets: 'pr-preview'
+          folder: ./out
+          branch: gh-pages
+          clean-exclude: pr-preview/
+          force: false


### PR DESCRIPTION
## Summary
- Replace `peaceiris/actions-gh-pages` with `JamesIves/github-pages-deploy-action` for GitHub Pages deployments
- Configure `clean-exclude: pr-preview/` to preserve PR preview directories during deployment
- Set `force: false` to use rebase instead of force-push, respecting concurrent preview deployments

This follows the [pr-preview-action recommendations](https://github.com/rossjrw/pr-preview-action#ensure-your-main-deployment-is-compatible) to ensure main deployments don't delete active PR previews.

## Test plan
- [ ] Verify main branch deployment succeeds
- [ ] Verify existing PR previews are preserved after main deployment