### PR TITLE
fix: split combined author/bar attributions into separate entries

### DIFF
--- a/src/data/recipes/book/minimalist-tiki/waikiki-at-dusk-forever.json
+++ b/src/data/recipes/book/minimalist-tiki/waikiki-at-dusk-forever.json
@@ -72,7 +72,11 @@
   ],
   "attributions": [
     {
-      "source": "Shelby Allison and Erin Hayes",
+      "source": "Shelby Allison",
+      "relation": "recipe author"
+    },
+    {
+      "source": "Erin Hayes",
       "relation": "recipe author"
     }
   ],

--- a/src/data/recipes/youtube-channel/make-and-drink/monkeypod-mai-tai.json
+++ b/src/data/recipes/youtube-channel/make-and-drink/monkeypod-mai-tai.json
@@ -71,7 +71,11 @@
   "attributions": [
     {
       "relation": "recipe author",
-      "source": "Jason Vendrell & Chandra Lam"
+      "source": "Jason Vendrell"
+    },
+    {
+      "relation": "recipe author",
+      "source": "Chandra Lam"
     },
     {
       "relation": "bar",


### PR DESCRIPTION
## Summary
- Splits combined author attributions that use "and" or "&" into separate entries
- Each person now gets their own attribution entry
- Adds validation in `check-data` to catch future combined author attributions
- Affected recipes: Waikiki at Dusk Forever, Monkeypod Mai Tai

## Test plan
- [x] `yarn check-data` passes
- [x] Validation correctly catches "First Last and First Last" patterns
- [x] Validation ignores brand names like "Make and Drink"