### PR TITLE
fix: show attribution for non-unique recipe names across all list views

### DIFF
--- a/src/app/list/authors/[name]/AuthorRecipesClient.tsx
+++ b/src/app/list/authors/[name]/AuthorRecipesClient.tsx
@@ -2,31 +2,16 @@
 
 import { Card, CardHeader } from '@mui/material';
 import { useQueryState } from 'nuqs';
+import { useCallback } from 'react';
 import type { Recipe } from '@/types/Recipe';
 import { LinkList, LinkListItem } from '@/components/LinkList';
 import SearchableList from '@/components/SearchableList';
 import SearchAllLink from '@/components/SearchAllLink';
 import SearchHeader from '@/components/SearchHeader';
+import useNameIsUnique from '@/hooks/useNameIsUnique';
+import { getRecipeAttribution } from '@/modules/getRecipeAttribution';
 import { getRecipeSearchText } from '@/modules/searchText';
 import { getRecipeUrl } from '@/modules/url';
-
-function renderRecipe(recipe: Recipe, authorName: string) {
-  // Get the attribution if the recipe was adapted by someone else
-  const adaptedBy = recipe.attributions.find(
-    (attribution) =>
-      attribution.relation === 'adapted by' && attribution.source !== authorName,
-  );
-
-  const href = getRecipeUrl(recipe);
-  return (
-    <LinkListItem
-      key={href}
-      href={href}
-      primary={recipe.name}
-      secondary={adaptedBy ? `Adapted by ${adaptedBy.source}` : undefined}
-    />
-  );
-}
 
 export default function AuthorRecipesClient({
   authorName,
@@ -37,6 +22,7 @@ export default function AuthorRecipesClient({
 }) {
   const [searchTerm, setSearchTerm] = useQueryState('search');
   const isSearching = searchTerm != null && searchTerm.trim() !== '';
+  const nameIsUnique = useNameIsUnique(recipes);
 
   const emptyState = (
     <>
@@ -47,7 +33,20 @@ export default function AuthorRecipesClient({
     </>
   );
 
-  const renderItem = (recipe: Recipe) => renderRecipe(recipe, authorName);
+  const renderItem = useCallback(
+    (recipe: Recipe) => {
+      const href = getRecipeUrl(recipe);
+      return (
+        <LinkListItem
+          key={href}
+          href={href}
+          primary={recipe.name}
+          secondary={nameIsUnique(recipe) ? undefined : getRecipeAttribution(recipe)}
+        />
+      );
+    },
+    [nameIsUnique],
+  );
 
   return (
     <>

--- a/src/app/list/bars/[name]/BarRecipesClient.tsx
+++ b/src/app/list/bars/[name]/BarRecipesClient.tsx
@@ -2,18 +2,16 @@
 
 import { Card, CardHeader } from '@mui/material';
 import { useQueryState } from 'nuqs';
+import { useCallback } from 'react';
 import type { Recipe } from '@/types/Recipe';
 import { LinkList, LinkListItem } from '@/components/LinkList';
 import SearchableList from '@/components/SearchableList';
 import SearchAllLink from '@/components/SearchAllLink';
 import SearchHeader from '@/components/SearchHeader';
+import useNameIsUnique from '@/hooks/useNameIsUnique';
+import { getRecipeAttribution } from '@/modules/getRecipeAttribution';
 import { getRecipeSearchText } from '@/modules/searchText';
 import { getRecipeUrl } from '@/modules/url';
-
-function renderRecipe(recipe: Recipe) {
-  const href = getRecipeUrl(recipe);
-  return <LinkListItem key={href} href={href} primary={recipe.name} />;
-}
 
 export default function BarRecipesClient({
   barName,
@@ -24,6 +22,7 @@ export default function BarRecipesClient({
 }) {
   const [searchTerm, setSearchTerm] = useQueryState('search');
   const isSearching = searchTerm != null && searchTerm.trim() !== '';
+  const nameIsUnique = useNameIsUnique(recipes);
 
   const emptyState = (
     <>
@@ -32,6 +31,21 @@ export default function BarRecipesClient({
       </Card>
       <SearchAllLink searchTerm={searchTerm} />
     </>
+  );
+
+  const renderRecipe = useCallback(
+    (recipe: Recipe) => {
+      const href = getRecipeUrl(recipe);
+      return (
+        <LinkListItem
+          key={href}
+          href={href}
+          primary={recipe.name}
+          secondary={nameIsUnique(recipe) ? undefined : getRecipeAttribution(recipe)}
+        />
+      );
+    },
+    [nameIsUnique],
   );
 
   return (

--- a/src/app/source/[type]/[name]/SourceClient.tsx
+++ b/src/app/source/[type]/[name]/SourceClient.tsx
@@ -2,6 +2,7 @@
 
 import { Card, CardHeader } from '@mui/material';
 import { useQueryState } from 'nuqs';
+import { useCallback } from 'react';
 import type { Recipe } from '@/types/Recipe';
 import type { Source } from '@/types/Source';
 import { LinkList, LinkListItem } from '@/components/LinkList';
@@ -9,6 +10,8 @@ import SearchableList from '@/components/SearchableList';
 import SearchAllLink from '@/components/SearchAllLink';
 import SearchHeader from '@/components/SearchHeader';
 import SourceAboutCard from '@/components/SourceAboutCard';
+import useNameIsUnique from '@/hooks/useNameIsUnique';
+import { getRecipeAttribution } from '@/modules/getRecipeAttribution';
 import { getRecipeSearchText } from '@/modules/searchText';
 import { getRecipeUrl } from '@/modules/url';
 
@@ -21,6 +24,7 @@ export default function SourceClient({
 }) {
   const [searchTerm, setSearchTerm] = useQueryState('search');
   const isSearching = searchTerm != null && searchTerm.trim() !== '';
+  const nameIsUnique = useNameIsUnique(recipes);
 
   const emptyState = (
     <>
@@ -31,10 +35,20 @@ export default function SourceClient({
     </>
   );
 
-  const renderRecipe = (recipe: Recipe) => {
-    const href = getRecipeUrl(recipe);
-    return <LinkListItem key={href} href={href} primary={recipe.name} />;
-  };
+  const renderRecipe = useCallback(
+    (recipe: Recipe) => {
+      const href = getRecipeUrl(recipe);
+      return (
+        <LinkListItem
+          key={href}
+          href={href}
+          primary={recipe.name}
+          secondary={nameIsUnique(recipe) ? undefined : getRecipeAttribution(recipe)}
+        />
+      );
+    },
+    [nameIsUnique],
+  );
 
   return (
     <>


### PR DESCRIPTION
## Summary
- AuthorRecipesClient, BarRecipesClient, and SourceClient now show attribution when multiple recipes share the same name
- Uses the existing `useNameIsUnique` hook and `getRecipeAttribution` function for consistency with RecipesClient and IngredientClient
- For author pages, when names are unique but the recipe was adapted by someone else, it still shows "Adapted by X"

## Test plan
- [ ] Visit https://sboudrias.github.io/cocktails/list/authors/william-prestwood (or preview) and verify duplicate recipe names now show attribution
- [ ] Verify other author/bar/source pages correctly show attribution only when names aren't unique
- [ ] Run `yarn lint` and `yarn vitest --run` to verify all checks pass