### PR TITLE
feat: Add weekly YouTube video tracking automation

### DIFF
--- a/.claude/skills/youtube/SKILL.md
+++ b/.claude/skills/youtube/SKILL.md
@@ -64,6 +64,22 @@ When adding a new YouTube channel to the cocktails app:
 
 This creates a GitHub issue listing all videos from the channel that don't have recipes yet.
 
+## YouTube API Configuration
+
+The sync tool supports two methods for fetching videos:
+
+1. **YouTube Data API v3** (Recommended) - Reliable, fast, and works in CI environments
+   - Set `YOUTUBE_API_KEY` environment variable with your API key
+   - Get a free API key from [Google Cloud Console](https://console.cloud.google.com/apis/credentials)
+   - 50 quota units/day = ~1,667 API calls (more than enough for this use case)
+   - Add as GitHub secret: Repository Settings → Secrets → Actions → `YOUTUBE_API_KEY`
+
+2. **yt-dlp** (Fallback) - Used automatically if API key not available
+   - Works locally but may be blocked by YouTube in CI environments
+   - No configuration needed, but less reliable in automated contexts
+
+The tool automatically tries the API first (if key available), then falls back to yt-dlp if needed.
+
 ## Channel Video Sync
 
 A GitHub Action runs weekly to check all channels for new videos and creates an issue if any are found.

--- a/.github/workflows/youtube-sync.yml
+++ b/.github/workflows/youtube-sync.yml
@@ -26,4 +26,5 @@ jobs:
       - name: Run YouTube sync 📺
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
         run: yarn youtube-sync

--- a/tools/youtube-api.ts
+++ b/tools/youtube-api.ts
@@ -1,0 +1,194 @@
+/**
+ * YouTube Data API v3 client for fetching video metadata
+ * Docs: https://developers.google.com/youtube/v3/docs
+ */
+
+export interface Video {
+  id: string;
+  title: string;
+  url: string;
+  upload_date: string; // Format: YYYYMMDD
+}
+
+interface YouTubeVideoSnippet {
+  publishedAt: string;
+  title: string;
+  resourceId: {
+    videoId: string;
+  };
+}
+
+interface YouTubePlaylistItem {
+  snippet: YouTubeVideoSnippet;
+}
+
+interface YouTubePlaylistResponse {
+  items: YouTubePlaylistItem[];
+  nextPageToken?: string;
+}
+
+interface YouTubeChannel {
+  contentDetails: {
+    relatedPlaylists: {
+      uploads: string;
+    };
+  };
+}
+
+interface YouTubeChannelResponse {
+  items: YouTubeChannel[];
+}
+
+/**
+ * Extract channel ID or username from YouTube URL
+ */
+function extractChannelIdentifier(url: string): {
+  type: 'id' | 'username';
+  value: string;
+} {
+  // Handle @username URLs
+  const usernameMatch = url.match(/@([\w-]+)/);
+  if (usernameMatch?.[1]) {
+    return { type: 'username', value: usernameMatch[1] };
+  }
+
+  // Handle /channel/ID URLs
+  const channelMatch = url.match(/\/channel\/([\w-]+)/);
+  if (channelMatch?.[1]) {
+    return { type: 'id', value: channelMatch[1] };
+  }
+
+  // Handle custom URLs like /c/name
+  const customMatch = url.match(/\/c\/([\w-]+)/);
+  if (customMatch?.[1]) {
+    return { type: 'username', value: customMatch[1] };
+  }
+
+  throw new Error(`Could not extract channel identifier from URL: ${url}`);
+}
+
+/**
+ * Get the uploads playlist ID for a channel
+ */
+async function getUploadsPlaylistId(apiKey: string, channelUrl: string): Promise<string> {
+  const identifier = extractChannelIdentifier(channelUrl);
+
+  const params = new URLSearchParams({
+    part: 'contentDetails',
+    key: apiKey,
+  });
+
+  if (identifier.type === 'id') {
+    params.append('id', identifier.value);
+  } else {
+    params.append('forHandle', identifier.value);
+  }
+
+  const url = `https://www.googleapis.com/youtube/v3/channels?${params.toString()}`;
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`YouTube API error (${response.status}): ${error}`);
+  }
+
+  const data = (await response.json()) as YouTubeChannelResponse;
+
+  if (!data.items || data.items.length === 0) {
+    throw new Error('Channel not found');
+  }
+
+  return data.items[0]!.contentDetails.relatedPlaylists.uploads;
+}
+
+/**
+ * Fetch videos from a playlist with pagination
+ */
+async function fetchPlaylistVideos(
+  apiKey: string,
+  playlistId: string,
+  maxResults = 100,
+): Promise<Video[]> {
+  const videos: Video[] = [];
+  let pageToken: string | undefined;
+  let remainingResults = maxResults;
+
+  while (remainingResults > 0) {
+    const perPage = Math.min(remainingResults, 50); // API max is 50 per page
+    const params = new URLSearchParams({
+      part: 'snippet',
+      playlistId,
+      maxResults: perPage.toString(),
+      key: apiKey,
+    });
+
+    if (pageToken) {
+      params.append('pageToken', pageToken);
+    }
+
+    const url = `https://www.googleapis.com/youtube/v3/playlistItems?${params.toString()}`;
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`YouTube API error (${response.status}): ${error}`);
+    }
+
+    const data = (await response.json()) as YouTubePlaylistResponse;
+
+    for (const item of data.items) {
+      const snippet = item.snippet;
+      const publishDate = new Date(snippet.publishedAt);
+
+      videos.push({
+        id: snippet.resourceId.videoId,
+        title: snippet.title,
+        url: `https://youtube.com/watch?v=${snippet.resourceId.videoId}`,
+        upload_date: formatDateYYYYMMDD(publishDate),
+      });
+    }
+
+    remainingResults -= data.items.length;
+    pageToken = data.nextPageToken;
+
+    // Break if no more pages
+    if (!pageToken) break;
+  }
+
+  return videos;
+}
+
+/**
+ * Format Date object to YYYYMMDD string
+ */
+function formatDateYYYYMMDD(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}${month}${day}`;
+}
+
+/**
+ * Fetch recent videos from a YouTube channel using the YouTube Data API
+ * @param apiKey YouTube Data API v3 key
+ * @param channelUrl Full YouTube channel URL
+ * @param maxResults Maximum number of videos to fetch (default: 100)
+ * @returns Array of videos with metadata
+ */
+export async function fetchChannelVideos(
+  apiKey: string,
+  channelUrl: string,
+  maxResults = 100,
+): Promise<Video[]> {
+  try {
+    // Get the uploads playlist ID for this channel
+    const uploadsPlaylistId = await getUploadsPlaylistId(apiKey, channelUrl);
+
+    // Fetch videos from the uploads playlist
+    const videos = await fetchPlaylistVideos(apiKey, uploadsPlaylistId, maxResults);
+
+    return videos;
+  } catch (error) {
+    throw new Error(`Failed to fetch videos via API: ${(error as Error).message}`);
+  }
+}


### PR DESCRIPTION
## Summary

Adds automated weekly tracking of YouTube channels to discover new videos without recipes. A GitHub Action runs every Monday to check all tracked channels and creates an issue listing new videos.

## Key Features

- **Weekly automation**: GitHub Action runs every Monday at 9 AM UTC
- **Smart video fetching**: Uses YouTube Data API v3 (with yt-dlp fallback for local dev)
- **Issue creation**: Automatically creates GitHub issues with formatted video lists
- **CLI tool**: `yarn youtube-sync` command with flags for testing and backfilling
- **Shared utilities**: New `tools/cli-util.ts` for consistent logging across tools

## Files Added/Modified

**New files:**
- `tools/youtube-sync.ts` - Main sync tool with CLI interface
- `tools/youtube-api.ts` - YouTube Data API v3 client
- `tools/cli-util.ts` - Shared logging utilities
- `.github/workflows/youtube-sync.yml` - Weekly automation workflow
- `.claude/skills/youtube/SKILL.md` - Documentation for YouTube workflows

**Modified:**
- `tools/check-data.ts` - Refactored to use shared logger utilities
- `package.json` - Added `commander` dependency and `youtube-sync` script

## YouTube API Setup (Required for CI)

The tool uses YouTube Data API v3 in CI environments (solves bot detection issues):

1. Get a free API key from [Google Cloud Console](https://console.cloud.google.com/apis/credentials)
2. Add as GitHub secret: `YOUTUBE_API_KEY`
3. The tool auto-detects the key and uses the API, falling back to yt-dlp locally

## CLI Usage

```bash
# Check all channels (last 7 days)
yarn youtube-sync --dry-run

# Backfill a specific channel
yarn youtube-sync --channel educated-barfly --days 365 --dry-run
yarn youtube-sync --channel educated-barfly --days 365

# Available options
yarn youtube-sync --help
```

## Test Plan

- [x] Tool runs successfully with both API and yt-dlp methods
- [x] Correctly identifies new videos vs existing recipes
- [x] Formats issue markdown properly
- [x] CLI flags work as expected (--dry-run, --days, --channel)
- [x] All linting and type checks pass
- [x] Shared logger utilities work in check-data.ts
- [ ] Test GitHub Action after API key is added to secrets
- [ ] Verify issue creation in production

## Notes

- The yt-dlp code is kept as a fallback for local development
- Weekly runs will only check videos from the last 7 days
- Manual workflow dispatch available for testing
- Backfilling documented for adding new channels