### PR TITLE
fix: youtube sync import and add type checking

### DIFF
--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -9,6 +9,7 @@
     "./categories": "./src/modules/categories.ts",
     "./ingredients": "./src/modules/ingredients.ts",
     "./sources": "./src/modules/sources.ts",
+    "./constants": "./src/modules/constants.ts",
     "./params": "./src/modules/params.ts",
     "./schemas/*": "./schemas/*"
   },

--- a/packages/youtube-sync/package.json
+++ b/packages/youtube-sync/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "lint": "tsc --noEmit",
     "youtube-sync": "node src/youtube-sync.ts"
   },
   "dependencies": {

--- a/packages/youtube-sync/src/youtube-sync.ts
+++ b/packages/youtube-sync/src/youtube-sync.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S node --no-warnings
 
-import { YOUTUBE_CHANNEL_ROOT } from '@cocktails/data';
+import { YOUTUBE_CHANNEL_ROOT } from '@cocktails/data/constants';
 import { Command } from 'commander';
 import { execSync } from 'node:child_process';
 import fs from 'node:fs/promises';

--- a/packages/youtube-sync/tsconfig.json
+++ b/packages/youtube-sync/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- Fix `YOUTUBE_CHANNEL_ROOT` import in youtube-sync by adding `./constants` subpath export to `@cocktails/data` and updating the import to `@cocktails/data/constants`
- Add type checking to the youtube-sync package (`tsconfig.json` + `lint` script) so type errors are caught by `yarn lint`

## Test plan
- [x] `yarn lint` passes
- [x] `yarn workspace @cocktails/youtube-sync lint` type checks successfully
- [x] `yarn vitest --run` passes (no regressions)