### PR TITLE
fix: round scaled quantities to measurable fractions

### DIFF
--- a/apps/web/components/Quantity/index.tsx
+++ b/apps/web/components/Quantity/index.tsx
@@ -67,7 +67,7 @@ export default function Quantity({
   let displayAmount: number | string = amount;
 
   if (unitType[unit] === 'imperial') {
-    const rounded = roundToFriendlyFraction(amount);
+    const rounded = roundToFriendlyFraction(amount, unit);
     const base = Math.floor(rounded);
     const fraction = Math.round((rounded - base + Number.EPSILON) * 100) / 100;
 

--- a/apps/web/modules/friendly-rounding.test.ts
+++ b/apps/web/modules/friendly-rounding.test.ts
@@ -2,25 +2,50 @@ import { describe, expect, it } from 'vitest';
 import { roundToFriendlyFraction, roundToFriendlyMl } from './friendly-rounding';
 
 describe('roundToFriendlyFraction', () => {
-  it.each([
-    [1.7, 1.67],
-    [2.4, 2.33],
-    [1.35, 1.33],
-    [3.4, 3.33],
-  ])('rounds %f → %f', (input, expected) => {
-    expect(roundToFriendlyFraction(input)).toBe(expected);
+  describe('oz (quarters + thirds)', () => {
+    it.each([
+      [1.7, 1.67],
+      [2.4, 2.33],
+      [1.35, 1.33],
+      [3.4, 3.33],
+    ])('rounds %f → %f', (input, expected) => {
+      expect(roundToFriendlyFraction(input, 'oz')).toBe(expected);
+    });
+
+    it('rounds 0.9 up to 1', () => {
+      expect(roundToFriendlyFraction(0.9, 'oz')).toBe(1);
+    });
+
+    it('rounds 2.1 down to 2', () => {
+      expect(roundToFriendlyFraction(2.1, 'oz')).toBe(2);
+    });
+
+    it('passes whole numbers through unchanged', () => {
+      expect(roundToFriendlyFraction(3, 'oz')).toBe(3);
+    });
   });
 
-  it('rounds 0.9 up to 1', () => {
-    expect(roundToFriendlyFraction(0.9)).toBe(1);
-  });
+  describe('tsp/tbsp/cup (quarters only)', () => {
+    it.each([
+      [1.7, 1.75],
+      [2.4, 2.5],
+      [1.35, 1.25],
+      [3.4, 3.5],
+    ])('rounds %f → %f', (input, expected) => {
+      expect(roundToFriendlyFraction(input, 'tsp')).toBe(expected);
+    });
 
-  it('rounds 2.1 down to 2', () => {
-    expect(roundToFriendlyFraction(2.1)).toBe(2);
-  });
+    it('rounds 0.9 up to 1', () => {
+      expect(roundToFriendlyFraction(0.9, 'tbsp')).toBe(1);
+    });
 
-  it('passes whole numbers through unchanged', () => {
-    expect(roundToFriendlyFraction(3)).toBe(3);
+    it('rounds 2.1 down to 2', () => {
+      expect(roundToFriendlyFraction(2.1, 'cup')).toBe(2);
+    });
+
+    it('defaults to oz targets when no unit provided', () => {
+      expect(roundToFriendlyFraction(1.7)).toBe(1.67);
+    });
   });
 });
 

--- a/apps/web/modules/friendly-rounding.ts
+++ b/apps/web/modules/friendly-rounding.ts
@@ -1,13 +1,12 @@
-const FRACTION_TARGETS = [0, 0.25, 0.33, 0.5, 0.67, 0.75, 1];
+// Jiggers have ⅓ and ⅔ marks; measuring spoons/cups only have quarter increments
+const OZ_TARGETS = [0, 0.25, 0.33, 0.5, 0.67, 0.75, 1];
+const QUARTER_TARGETS = [0, 0.25, 0.5, 0.75, 1];
 
-export function roundToFriendlyFraction(amount: number): number {
-  const base = Math.floor(amount);
-  const fraction = amount - base;
-
-  let closest = FRACTION_TARGETS[0]!;
+function snapFraction(fraction: number, targets: number[]): number {
+  let closest = targets[0]!;
   let minDiff = Math.abs(fraction - closest);
 
-  for (const target of FRACTION_TARGETS) {
+  for (const target of targets) {
     const diff = Math.abs(fraction - target);
     if (diff < minDiff) {
       minDiff = diff;
@@ -15,7 +14,15 @@ export function roundToFriendlyFraction(amount: number): number {
     }
   }
 
-  return base + closest;
+  return closest;
+}
+
+export function roundToFriendlyFraction(amount: number, unit: string = 'oz'): number {
+  const base = Math.floor(amount);
+  const fraction = amount - base;
+  const targets = unit === 'oz' ? OZ_TARGETS : QUARTER_TARGETS;
+
+  return base + snapFraction(fraction, targets);
 }
 
 export function roundToFriendlyMl(amount: number): number {


### PR DESCRIPTION
## Summary

Fixes #33 — When scaling recipes up or down, exact decimal values (e.g. 1.7 oz, 2.4 oz, 51 ml) didn't map to any known display fraction and were impractical to measure with standard bar tools.

- Add friendly rounding at the display layer in the `Quantity` component
- Imperial units (oz, tsp, tbsp, cup) snap to the nearest quarter or third fraction (¼, ⅓, ½, ⅔, ¾)
- Metric (ml) rounds to the nearest 5 ml (or 2.5 ml for small amounts under 15 ml)
- Counting units (dash, drop, pinch, spray, gram) round to the nearest whole number
- At 1x scale, original recipe values pass through unchanged (existing behavior)
- Scaling module continues to produce exact values, preserving precision for unit conversion and juice URL calculations

### Example: Antilles Jewel scaled to 2 servings

| Ingredient | Exact | oz display | ml display |
|---|---|---|---|
| Coconut water | 1.7 oz | 1 ⅔ oz | 50 ml |
| Lime juice | 2.4 oz | 2 ⅓ oz | 70 ml |
| Crème de Cacao | 0.666 oz | ⅔ oz | 20 ml |
| Crème de banane | 1.35 oz | 1 ⅓ oz | 40 ml |
| Hamilton 86 | 1.7 oz | 1 ⅔ oz | 50 ml |
| Mount Gay | 3.4 oz | 3 ⅓ oz | 100 ml |

## Test plan

- [x] New unit tests for `roundToFriendlyFraction` and `roundToFriendlyMl`
- [x] Existing tests pass (IngredientList scaling, conversion, etc.)
- [x] Lint and type checking pass
- [ ] Manual: open Antilles Jewel, scale to 2 servings in both oz and ml, verify readable fractions