### PR TITLE
fix: prevent ⅛ oz quantities from displaying as 0

### DIFF
--- a/apps/web/modules/friendly-rounding.test.ts
+++ b/apps/web/modules/friendly-rounding.test.ts
@@ -12,12 +12,16 @@ describe('roundToFriendlyFraction', () => {
       expect(roundToFriendlyFraction(input, 'oz')).toBe(expected);
     });
 
-    it('rounds 0.9 up to 1', () => {
-      expect(roundToFriendlyFraction(0.9, 'oz')).toBe(1);
+    it('preserves ⅛ oz instead of rounding to 0', () => {
+      expect(roundToFriendlyFraction(0.125, 'oz')).toBe(0.125);
     });
 
-    it('rounds 2.1 down to 2', () => {
-      expect(roundToFriendlyFraction(2.1, 'oz')).toBe(2);
+    it('rounds 0.9 to ⅞', () => {
+      expect(roundToFriendlyFraction(0.9, 'oz')).toBe(0.875);
+    });
+
+    it('rounds 2.1 to 2⅛', () => {
+      expect(roundToFriendlyFraction(2.1, 'oz')).toBe(2.125);
     });
 
     it('passes whole numbers through unchanged', () => {

--- a/apps/web/modules/friendly-rounding.ts
+++ b/apps/web/modules/friendly-rounding.ts
@@ -1,5 +1,5 @@
-// Jiggers have ⅓ and ⅔ marks; measuring spoons/cups only have quarter increments
-const OZ_TARGETS = [0, 0.25, 0.33, 0.5, 0.67, 0.75, 1];
+// Jiggers have ⅓ and ⅔ marks; measuring spoons/cups only have quarter and eighth increments
+const OZ_TARGETS = [0, 0.125, 0.25, 0.33, 0.5, 0.67, 0.75, 0.875, 1];
 const QUARTER_TARGETS = [0, 0.25, 0.5, 0.75, 1];
 
 function snapFraction(fraction: number, targets: number[]): number {


### PR DESCRIPTION
## Summary
- Added `0.125` (⅛) and `0.875` (⅞) to `OZ_TARGETS` in the friendly-rounding module
- These values were already supported by the `displayFraction` map but missing from the rounding targets, causing amounts like `0.125 oz` to snap to `0` instead of being preserved

Fixes #142

## Test plan
- [x] Unit tests updated and passing for `roundToFriendlyFraction`
- [x] Verified the Pimm's Tropicale recipe (0.125 oz lemon/lime juice) no longer rounds to 0
- [x] Full test suite passes (pre-existing localStorage failures in source page tests are unrelated)