### PR TITLE
fix: round grams to one decimal instead of whole numbers

### DIFF
--- a/apps/web/components/Quantity/index.tsx
+++ b/apps/web/components/Quantity/index.tsx
@@ -35,7 +35,7 @@ const displayFraction: Record<number, string> = {
 
 const unitType: Record<
   RecipeIngredient['quantity']['unit'],
-  'imperial' | 'metric' | 'counting'
+  'imperial' | 'metric' | 'weight' | 'counting'
 > = {
   oz: 'imperial',
   tsp: 'imperial',
@@ -43,10 +43,10 @@ const unitType: Record<
   cup: 'imperial',
   unit: 'imperial',
   ml: 'metric',
+  gram: 'weight',
   bottle: 'counting',
   dash: 'counting',
   drop: 'counting',
-  gram: 'counting',
   pinch: 'counting',
   spray: 'counting',
   part: 'counting',
@@ -81,6 +81,8 @@ export default function Quantity({
     }
   } else if (unitType[unit] === 'metric') {
     displayAmount = roundToFriendlyMl(amount);
+  } else if (unitType[unit] === 'weight') {
+    displayAmount = Math.round(amount * 10) / 10;
   } else {
     displayAmount = Math.round(amount);
   }


### PR DESCRIPTION
## Summary
- Grams were classified as `counting` units (like dashes, drops, pinches) and rounded with `Math.round()`, causing 0.3g to display as "0"
- Added a `weight` unit type that rounds to one decimal place (`Math.round(amount * 10) / 10`)
- Fixes the Ron Coco recipe where 0.3g of acid solution was showing as 0

Fixes #152

## Test plan
- [x] All 330 existing tests pass
- [x] Lint and typecheck pass
- [ ] Verify Ron Coco recipe displays "0.3 gram" instead of "0"
- [ ] Verify recipes with whole gram amounts (e.g. 60g, 125g) still display correctly