### PR TITLE
chore: add infusion technique and bottle dedup rules to agent instructions

### DIFF
--- a/.claude/agents/ingredient-validator.md
+++ b/.claude/agents/ingredient-validator.md
@@ -22,6 +22,12 @@ When helping with recipe or ingredient creation, you will:
 
 7. **Proactive Guidance**: When you notice potential naming inconsistencies or type misassignments, immediately flag them and suggest corrections based on existing data patterns.
 
+8. **Infused Spirits Are Techniques, NOT Bottles**: When a recipe calls for something like "Chamomile-Infused Armagnac" or "Elote-Infused Elijah Craig Bourbon", this is NOT a separate ingredient. Do NOT create ingredient files for infused spirits. Instead, the recipe should reference the base spirit (e.g., "Château du Tariquet 15 Year Armagnac") with a technique field: `"technique": {"technique": "infusion", "agent": "chamomile"}`. The same applies to fat-washed, tea-infused, pepper-infused, milk-washed, and other modified spirits. See `packages/data/schemas/technique.schema.json` for all supported technique types.
+
+9. **Renamed Products**: Some spirit brands have been renamed over time. Always search existing ingredient files thoroughly before creating new ones. Known renames include:
+   - "Appleton Estate Reserve" → "Appleton 8" (`appleton-8.json`)
+   - "Appleton Estate V/X" → "Appleton Signature" (`appleton-signature.json`)
+
 Your responses should be decisive and specific, always referencing the actual ingredient names found in the existing data files. If you're uncertain about whether an ingredient exists or what type it should be, explicitly state that you need to check the current ingredient data before proceeding.
 
 Always prioritize data consistency over user preferences when it comes to naming - the integrity of the ingredient database is paramount.

--- a/.claude/commands/create-recipes.md
+++ b/.claude/commands/create-recipes.md
@@ -4,3 +4,5 @@ Don't forget:
 
 1. Get help from the ingredient-validator sub-agent.
 2. Use the youtube skill if I give you youtube.com links
+3. **Infused spirits are techniques, NOT separate bottles.** When a recipe calls for something like "Chamomile-Infused Armagnac", use the base spirit (e.g., "Château du Tariquet 15 Year Armagnac") with `"technique": {"technique": "infusion", "agent": "chamomile"}`. Never create ingredient files for infused spirits. Same applies to fat-washed, tea-infused, pepper-infused, etc.
+4. **Watch out for renamed products.** Some spirit brands have been renamed over time (e.g., "Appleton Estate Reserve" → "Appleton 8", "Appleton Estate V/X" → "Appleton Signature"). Always search existing ingredient files before creating new ones.


### PR DESCRIPTION
## Summary
- Document that infused spirits should use the base spirit + technique field, not separate ingredient files
- Add known product renames (Appleton Estate Reserve → Appleton 8, V/X → Signature)
- Updates both `ingredient-validator` agent and `create-recipes` command

## Test plan
- [x] No code changes, documentation only