### PR TITLE
feat: Death & Co Welcome Home - Chapter 4 "Boozy & Honest (Old-Fashioned)"

### DIFF
--- a/packages/data/data/categories/apple-liqueur.json
+++ b/packages/data/data/categories/apple-liqueur.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../schemas/category.schema.json",
+  "name": "Apple liqueur",
+  "categoryType": "liqueur"
+}

--- a/packages/data/data/categories/armagnac.json
+++ b/packages/data/data/categories/armagnac.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../schemas/category.schema.json",
+  "name": "Armagnac",
+  "categoryType": "spirit",
+  "parents": ["Brandy (Grapes)"]
+}

--- a/packages/data/data/categories/basil-liqueur.json
+++ b/packages/data/data/categories/basil-liqueur.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../schemas/category.schema.json",
+  "name": "Basil liqueur",
+  "categoryType": "liqueur"
+}

--- a/packages/data/data/categories/brandy-peach.json
+++ b/packages/data/data/categories/brandy-peach.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../schemas/category.schema.json",
+  "name": "Brandy (Peach)",
+  "categoryType": "spirit"
+}

--- a/packages/data/data/categories/creme-de-rose.json
+++ b/packages/data/data/categories/creme-de-rose.json
@@ -1,5 +1,5 @@
 {
   "$schema": "../../schemas/category.schema.json",
-  "name": "Rose liqueur",
+  "name": "Crème de Rose",
   "categoryType": "liqueur"
 }

--- a/packages/data/data/categories/kuemmel.json
+++ b/packages/data/data/categories/kuemmel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../schemas/category.schema.json",
+  "name": "Kümmel",
+  "categoryType": "liqueur"
+}

--- a/packages/data/data/categories/plum-wine.json
+++ b/packages/data/data/categories/plum-wine.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../schemas/category.schema.json",
+  "name": "Plum wine",
+  "categoryType": "wine"
+}

--- a/packages/data/data/categories/rose-liqueur.json
+++ b/packages/data/data/categories/rose-liqueur.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../schemas/category.schema.json",
+  "name": "Rose liqueur",
+  "categoryType": "liqueur"
+}

--- a/packages/data/data/categories/strawberry-liqueur.json
+++ b/packages/data/data/categories/strawberry-liqueur.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../schemas/category.schema.json",
+  "name": "Strawberry liqueur",
+  "categoryType": "liqueur"
+}

--- a/packages/data/data/categories/whisky-islay-scotch.json
+++ b/packages/data/data/categories/whisky-islay-scotch.json
@@ -2,7 +2,7 @@
   "$schema": "../../schemas/category.schema.json",
   "name": "Whisky (Islay Scotch)",
   "categoryType": "spirit",
-  "parents": ["Whisky (Scotch)"],
+  "parents": ["Whisky (Scotch)", "Whisky (Peated)"],
   "refs": [
     {
       "type": "youtube",

--- a/packages/data/data/categories/whisky-peated.json
+++ b/packages/data/data/categories/whisky-peated.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../schemas/category.schema.json",
+  "name": "Whisky (Peated)",
+  "categoryType": "spirit"
+}

--- a/packages/data/data/ingredients/bitter/bitter-end-curry-bitters.json
+++ b/packages/data/data/ingredients/bitter/bitter-end-curry-bitters.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Bitter End Curry Bitters",
+  "type": "bitter"
+}

--- a/packages/data/data/ingredients/bitter/bitter-truth-peach-bitters.json
+++ b/packages/data/data/ingredients/bitter/bitter-truth-peach-bitters.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Bitter Truth Peach Bitters",
+  "type": "bitter"
+}

--- a/packages/data/data/ingredients/bitter/bittercube-jamaican-black-strap-bitters.json
+++ b/packages/data/data/ingredients/bitter/bittercube-jamaican-black-strap-bitters.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Bittercube Jamaican Black Strap Bitters",
+  "type": "bitter"
+}

--- a/packages/data/data/ingredients/bitter/house-orange-bitters.json
+++ b/packages/data/data/ingredients/bitter/house-orange-bitters.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "House Orange Bitters",
+  "type": "bitter",
+  "categories": ["Orange bitters"]
+}

--- a/packages/data/data/ingredients/bitter/house-orange-bitters.json
+++ b/packages/data/data/ingredients/bitter/house-orange-bitters.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "../../../schemas/ingredient.schema.json",
-  "name": "House Orange Bitters",
-  "type": "bitter",
-  "categories": ["Orange bitters"]
-}

--- a/packages/data/data/ingredients/bitter/miracle-mile-chocolate-chili-bitters.json
+++ b/packages/data/data/ingredients/bitter/miracle-mile-chocolate-chili-bitters.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Miracle Mile Chocolate Chili Bitters",
+  "type": "bitter"
+}

--- a/packages/data/data/ingredients/bitter/miracle-mile-yuzu-bitters.json
+++ b/packages/data/data/ingredients/bitter/miracle-mile-yuzu-bitters.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Miracle Mile Yuzu Bitters",
+  "type": "bitter"
+}

--- a/packages/data/data/ingredients/fruit/grapefruit.json
+++ b/packages/data/data/ingredients/fruit/grapefruit.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Grapefruit",
+  "type": "fruit"
+}

--- a/packages/data/data/ingredients/liqueur/amaro-sfumato.json
+++ b/packages/data/data/ingredients/liqueur/amaro-sfumato.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Amaro Sfumato",
+  "type": "liqueur",
+  "categories": ["Amaro"]
+}

--- a/packages/data/data/ingredients/liqueur/caffo-amaretto.json
+++ b/packages/data/data/ingredients/liqueur/caffo-amaretto.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Caffo Amaretto",
+  "type": "liqueur",
+  "categories": ["Amaretto"]
+}

--- a/packages/data/data/ingredients/liqueur/combier-creme-de-rose.json
+++ b/packages/data/data/ingredients/liqueur/combier-creme-de-rose.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Combier Crème de Rose",
+  "type": "liqueur",
+  "categories": ["Rose liqueur"]
+}

--- a/packages/data/data/ingredients/liqueur/creme-de-rose.json
+++ b/packages/data/data/ingredients/liqueur/creme-de-rose.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../../schemas/ingredient.schema.json",
-  "name": "Combier Crème de Rose",
+  "name": "Crème de Rose",
   "type": "liqueur",
   "categories": ["Rose liqueur"]
 }

--- a/packages/data/data/ingredients/liqueur/creme-de-rose.json
+++ b/packages/data/data/ingredients/liqueur/creme-de-rose.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "../../../schemas/ingredient.schema.json",
-  "name": "Crème de Rose",
-  "type": "liqueur",
-  "categories": ["Rose liqueur"]
-}

--- a/packages/data/data/ingredients/liqueur/dupont-pommeau-de-normandie.json
+++ b/packages/data/data/ingredients/liqueur/dupont-pommeau-de-normandie.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../../schemas/ingredient.schema.json",
   "name": "Dupont Pommeau de Normandie",
-  "type": "spirit",
-  "categories": ["Calvados"]
+  "type": "liqueur",
+  "categories": ["Apple liqueur"]
 }

--- a/packages/data/data/ingredients/liqueur/emile-pernot-fraise-de-bois.json
+++ b/packages/data/data/ingredients/liqueur/emile-pernot-fraise-de-bois.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Emile Pernot Fraise de Bois",
+  "type": "liqueur",
+  "categories": ["Strawberry liqueur"]
+}

--- a/packages/data/data/ingredients/liqueur/faretti-biscotti.json
+++ b/packages/data/data/ingredients/liqueur/faretti-biscotti.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../../schemas/ingredient.schema.json",
   "name": "Faretti Biscotti",
-  "type": "liqueur"
+  "type": "liqueur",
+  "categories": ["Amaretto"]
 }

--- a/packages/data/data/ingredients/liqueur/faretti-biscotti.json
+++ b/packages/data/data/ingredients/liqueur/faretti-biscotti.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Faretti Biscotti",
+  "type": "liqueur"
+}

--- a/packages/data/data/ingredients/liqueur/giffard-creme-de-framboise.json
+++ b/packages/data/data/ingredients/liqueur/giffard-creme-de-framboise.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Giffard Crème de Framboise",
+  "type": "liqueur",
+  "categories": ["Raspberry liqueur"]
+}

--- a/packages/data/data/ingredients/liqueur/jean-luc-pasquet-marie-framboise.json
+++ b/packages/data/data/ingredients/liqueur/jean-luc-pasquet-marie-framboise.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../../schemas/ingredient.schema.json",
   "name": "Jean-Luc Pasquet Marie-Framboise",
-  "type": "spirit",
-  "categories": ["Brandy (Raspberry)"]
+  "type": "liqueur",
+  "categories": ["Raspberry liqueur"]
 }

--- a/packages/data/data/ingredients/liqueur/massenez-garden-party.json
+++ b/packages/data/data/ingredients/liqueur/massenez-garden-party.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Massenez Garden Party",
+  "type": "liqueur",
+  "categories": ["Basil liqueur"]
+}

--- a/packages/data/data/ingredients/liqueur/merlet-creme-de-fraise-des-bois.json
+++ b/packages/data/data/ingredients/liqueur/merlet-creme-de-fraise-des-bois.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Merlet Crème de Fraise des Bois",
+  "type": "liqueur",
+  "categories": ["Strawberry liqueur"]
+}

--- a/packages/data/data/ingredients/spirit/agave-de-cortes-mezcal.json
+++ b/packages/data/data/ingredients/spirit/agave-de-cortes-mezcal.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Agave de Cortes Mezcal",
+  "type": "spirit",
+  "categories": ["Mezcal"]
+}

--- a/packages/data/data/ingredients/spirit/amrut-peated-cask-strength.json
+++ b/packages/data/data/ingredients/spirit/amrut-peated-cask-strength.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Amrut Peated Cask Strength",
+  "type": "spirit",
+  "categories": ["Whiskey"]
+}

--- a/packages/data/data/ingredients/spirit/amrut-peated-cask-strength.json
+++ b/packages/data/data/ingredients/spirit/amrut-peated-cask-strength.json
@@ -2,5 +2,5 @@
   "$schema": "../../../schemas/ingredient.schema.json",
   "name": "Amrut Peated Cask Strength",
   "type": "spirit",
-  "categories": ["Whiskey"]
+  "categories": ["Whisky (Peated)"]
 }

--- a/packages/data/data/ingredients/spirit/anchor-hophead-vodka.json
+++ b/packages/data/data/ingredients/spirit/anchor-hophead-vodka.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Anchor Hophead Vodka",
+  "type": "spirit",
+  "categories": ["Vodka"]
+}

--- a/packages/data/data/ingredients/spirit/appleton-21.json
+++ b/packages/data/data/ingredients/spirit/appleton-21.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Appleton 21",
+  "type": "spirit",
+  "categories": ["Blended Aged Rum (Jamaica)", "Jamaican Rum"]
+}

--- a/packages/data/data/ingredients/spirit/brugal-1888.json
+++ b/packages/data/data/ingredients/spirit/brugal-1888.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Brugal 1888",
+  "type": "spirit",
+  "categories": ["Column still aged rum"]
+}

--- a/packages/data/data/ingredients/spirit/calle-23-reposado.json
+++ b/packages/data/data/ingredients/spirit/calle-23-reposado.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Calle 23 Reposado",
+  "type": "spirit",
+  "categories": ["Tequila Reposado"]
+}

--- a/packages/data/data/ingredients/spirit/caol-ila-12-year.json
+++ b/packages/data/data/ingredients/spirit/caol-ila-12-year.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Caol Ila 12 Year",
+  "type": "spirit",
+  "categories": ["Whisky (Islay Scotch)"]
+}

--- a/packages/data/data/ingredients/spirit/cascahuin-48-plata.json
+++ b/packages/data/data/ingredients/spirit/cascahuin-48-plata.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Cascahuin 48 Plata",
+  "type": "spirit",
+  "categories": ["Tequila (Blanco)"]
+}

--- a/packages/data/data/ingredients/spirit/chateau-de-pellehaut-selection-armagnac.json
+++ b/packages/data/data/ingredients/spirit/chateau-de-pellehaut-selection-armagnac.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Château de Pellehaut Sélection Armagnac",
+  "type": "spirit",
+  "categories": ["Brandy (Grapes)"]
+}

--- a/packages/data/data/ingredients/spirit/chateau-de-pellehaut-selection-armagnac.json
+++ b/packages/data/data/ingredients/spirit/chateau-de-pellehaut-selection-armagnac.json
@@ -2,5 +2,5 @@
   "$schema": "../../../schemas/ingredient.schema.json",
   "name": "Château de Pellehaut Sélection Armagnac",
   "type": "spirit",
-  "categories": ["Brandy (Grapes)"]
+  "categories": ["Armagnac"]
 }

--- a/packages/data/data/ingredients/spirit/chateau-du-tariquet-15-year-armagnac.json
+++ b/packages/data/data/ingredients/spirit/chateau-du-tariquet-15-year-armagnac.json
@@ -2,5 +2,5 @@
   "$schema": "../../../schemas/ingredient.schema.json",
   "name": "Château du Tariquet 15 Year Armagnac",
   "type": "spirit",
-  "categories": ["Brandy (Grapes)"]
+  "categories": ["Armagnac"]
 }

--- a/packages/data/data/ingredients/spirit/cruzan-single-barrel.json
+++ b/packages/data/data/ingredients/spirit/cruzan-single-barrel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Cruzan Single Barrel",
+  "type": "spirit",
+  "categories": ["Column still aged rum"]
+}

--- a/packages/data/data/ingredients/spirit/del-bac-distillers-cut.json
+++ b/packages/data/data/ingredients/spirit/del-bac-distillers-cut.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Del Bac Distiller's Cut",
+  "type": "spirit",
+  "categories": ["Whiskey"]
+}

--- a/packages/data/data/ingredients/spirit/del-maguey-san-luis-del-rio-mezcal.json
+++ b/packages/data/data/ingredients/spirit/del-maguey-san-luis-del-rio-mezcal.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Del Maguey San Luis del Rio Mezcal",
+  "type": "spirit",
+  "categories": ["Mezcal"]
+}

--- a/packages/data/data/ingredients/spirit/delord-25-year-bas-armagnac.json
+++ b/packages/data/data/ingredients/spirit/delord-25-year-bas-armagnac.json
@@ -2,5 +2,5 @@
   "$schema": "../../../schemas/ingredient.schema.json",
   "name": "Delord 25 Year Bas Armagnac",
   "type": "spirit",
-  "categories": ["Brandy (Grapes)"]
+  "categories": ["Armagnac"]
 }

--- a/packages/data/data/ingredients/spirit/delord-25-year-bas-armagnac.json
+++ b/packages/data/data/ingredients/spirit/delord-25-year-bas-armagnac.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Delord 25 Year Bas Armagnac",
+  "type": "spirit",
+  "categories": ["Brandy (Grapes)"]
+}

--- a/packages/data/data/ingredients/spirit/domaine-d-esperance-blanche-armagnac.json
+++ b/packages/data/data/ingredients/spirit/domaine-d-esperance-blanche-armagnac.json
@@ -2,5 +2,5 @@
   "$schema": "../../../schemas/ingredient.schema.json",
   "name": "Domaine d'Espérance Blanche Armagnac",
   "type": "spirit",
-  "categories": ["Brandy (Grapes)"]
+  "categories": ["Armagnac"]
 }

--- a/packages/data/data/ingredients/spirit/dupont-pommeau-de-normandie.json
+++ b/packages/data/data/ingredients/spirit/dupont-pommeau-de-normandie.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Dupont Pommeau de Normandie",
+  "type": "spirit",
+  "categories": ["Calvados"]
+}

--- a/packages/data/data/ingredients/spirit/famous-grouse.json
+++ b/packages/data/data/ingredients/spirit/famous-grouse.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Famous Grouse",
+  "type": "spirit",
+  "categories": ["Whisky (Blended Scotch)"]
+}

--- a/packages/data/data/ingredients/spirit/george-dickel-rye.json
+++ b/packages/data/data/ingredients/spirit/george-dickel-rye.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "George Dickel Rye",
+  "type": "spirit",
+  "categories": ["Whiskey (Rye)"]
+}

--- a/packages/data/data/ingredients/spirit/glen-grant-10-year.json
+++ b/packages/data/data/ingredients/spirit/glen-grant-10-year.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Glen Grant 10 Year",
+  "type": "spirit",
+  "categories": ["Whisky (Scotch)"]
+}

--- a/packages/data/data/ingredients/spirit/gourry-de-chadeville-overproof-cognac.json
+++ b/packages/data/data/ingredients/spirit/gourry-de-chadeville-overproof-cognac.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Gourry de Chadeville Overproof Cognac",
+  "type": "spirit",
+  "categories": ["Cognac"]
+}

--- a/packages/data/data/ingredients/spirit/j-rieger-kansas-city-whiskey.json
+++ b/packages/data/data/ingredients/spirit/j-rieger-kansas-city-whiskey.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "J. Rieger Kansas City Whiskey",
+  "type": "spirit",
+  "categories": ["Whiskey (Bourbon)"]
+}

--- a/packages/data/data/ingredients/spirit/jean-luc-pasquet-marie-framboise.json
+++ b/packages/data/data/ingredients/spirit/jean-luc-pasquet-marie-framboise.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Jean-Luc Pasquet Marie-Framboise",
+  "type": "spirit",
+  "categories": ["Brandy (Raspberry)"]
+}

--- a/packages/data/data/ingredients/spirit/kappa-pisco.json
+++ b/packages/data/data/ingredients/spirit/kappa-pisco.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Kappa Pisco",
+  "type": "spirit",
+  "categories": ["Chilean pisco"]
+}

--- a/packages/data/data/ingredients/spirit/knob-creek-100.json
+++ b/packages/data/data/ingredients/spirit/knob-creek-100.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Knob Creek 100",
+  "type": "spirit",
+  "categories": ["Whiskey (Bourbon)"]
+}

--- a/packages/data/data/ingredients/spirit/lost-spirits-navy-style.json
+++ b/packages/data/data/ingredients/spirit/lost-spirits-navy-style.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Lost Spirits Navy Style",
+  "type": "spirit",
+  "categories": ["Navy style rum"]
+}

--- a/packages/data/data/ingredients/spirit/mal-bien-espadin-mezcal.json
+++ b/packages/data/data/ingredients/spirit/mal-bien-espadin-mezcal.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Mal Bien Espadin Mezcal",
+  "type": "spirit",
+  "categories": ["Mezcal"]
+}

--- a/packages/data/data/ingredients/spirit/massenez-kirsch-vieux.json
+++ b/packages/data/data/ingredients/spirit/massenez-kirsch-vieux.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Massenez Kirsch Vieux",
+  "type": "spirit",
+  "categories": ["Brandy (Cherry)"]
+}

--- a/packages/data/data/ingredients/spirit/massenez-kirschwasser.json
+++ b/packages/data/data/ingredients/spirit/massenez-kirschwasser.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Massenez Kirschwasser",
+  "type": "spirit",
+  "categories": ["Brandy (Cherry)"]
+}

--- a/packages/data/data/ingredients/spirit/navazos-palazzi-overseas-malt-whiskey.json
+++ b/packages/data/data/ingredients/spirit/navazos-palazzi-overseas-malt-whiskey.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Navazos Palazzi Overseas Malt Whiskey",
+  "type": "spirit",
+  "categories": ["Whiskey"]
+}

--- a/packages/data/data/ingredients/spirit/old-forester-signature.json
+++ b/packages/data/data/ingredients/spirit/old-forester-signature.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Old Forester Signature",
+  "type": "spirit",
+  "categories": ["Whiskey (Bourbon)"]
+}

--- a/packages/data/data/ingredients/spirit/peach-street-peach-brandy.json
+++ b/packages/data/data/ingredients/spirit/peach-street-peach-brandy.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Peach Street Peach Brandy",
+  "type": "spirit",
+  "categories": ["Brandy (Peach)"]
+}

--- a/packages/data/data/ingredients/spirit/ransom-old-tom.json
+++ b/packages/data/data/ingredients/spirit/ransom-old-tom.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Ransom Old Tom",
+  "type": "spirit",
+  "categories": ["Old Tom Gin"]
+}

--- a/packages/data/data/ingredients/spirit/rhine-hall-apple-brandy.json
+++ b/packages/data/data/ingredients/spirit/rhine-hall-apple-brandy.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Rhine Hall Apple Brandy",
+  "type": "spirit",
+  "categories": ["Brandy (Apple)"]
+}

--- a/packages/data/data/ingredients/spirit/siete-leguas-anejo-tequila.json
+++ b/packages/data/data/ingredients/spirit/siete-leguas-anejo-tequila.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Siete Leguas Añejo Tequila",
+  "type": "spirit",
+  "categories": ["Tequila Añejo"]
+}

--- a/packages/data/data/ingredients/spirit/springbank-10-year.json
+++ b/packages/data/data/ingredients/spirit/springbank-10-year.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Springbank 10 Year",
+  "type": "spirit",
+  "categories": ["Whisky (Scotch)"]
+}

--- a/packages/data/data/ingredients/spirit/st-george-terroir-gin.json
+++ b/packages/data/data/ingredients/spirit/st-george-terroir-gin.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "St. George Terroir Gin",
+  "type": "spirit",
+  "categories": ["Gin (New American)"]
+}

--- a/packages/data/data/ingredients/spirit/tariquet-classique-vs-armagnac.json
+++ b/packages/data/data/ingredients/spirit/tariquet-classique-vs-armagnac.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Tariquet Classique VS Armagnac",
+  "type": "spirit",
+  "categories": ["Brandy (Grapes)"]
+}

--- a/packages/data/data/ingredients/spirit/tariquet-classique-vs-armagnac.json
+++ b/packages/data/data/ingredients/spirit/tariquet-classique-vs-armagnac.json
@@ -2,5 +2,5 @@
   "$schema": "../../../schemas/ingredient.schema.json",
   "name": "Tariquet Classique VS Armagnac",
   "type": "spirit",
-  "categories": ["Brandy (Grapes)"]
+  "categories": ["Armagnac"]
 }

--- a/packages/data/data/ingredients/spirit/tequila-ocho-reposado.json
+++ b/packages/data/data/ingredients/spirit/tequila-ocho-reposado.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Tequila Ocho Reposado",
+  "type": "spirit",
+  "categories": ["Tequila Reposado"]
+}

--- a/packages/data/data/ingredients/spirit/torres-15-year-brandy.json
+++ b/packages/data/data/ingredients/spirit/torres-15-year-brandy.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Torres 15 Year Brandy",
+  "type": "spirit",
+  "categories": ["Brandy (Grapes)"]
+}

--- a/packages/data/data/ingredients/spirit/westward-american-single-malt.json
+++ b/packages/data/data/ingredients/spirit/westward-american-single-malt.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Westward American Single Malt",
+  "type": "spirit",
+  "categories": ["Whiskey"]
+}

--- a/packages/data/data/ingredients/syrup/house-orgeat.json
+++ b/packages/data/data/ingredients/syrup/house-orgeat.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "../../../schemas/ingredient.schema.json",
-  "name": "House Orgeat",
-  "type": "syrup"
-}

--- a/packages/data/data/ingredients/syrup/house-orgeat.json
+++ b/packages/data/data/ingredients/syrup/house-orgeat.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "House Orgeat",
+  "type": "syrup"
+}

--- a/packages/data/data/ingredients/syrup/sarsaparilla-demerara-syrup.json
+++ b/packages/data/data/ingredients/syrup/sarsaparilla-demerara-syrup.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Sarsaparilla Demerara Syrup",
+  "type": "syrup"
+}

--- a/packages/data/data/ingredients/tincture/terra-spice-root-beer-extract.json
+++ b/packages/data/data/ingredients/tincture/terra-spice-root-beer-extract.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Terra Spice Root Beer Extract",
+  "type": "tincture"
+}

--- a/packages/data/data/ingredients/tincture/terra-spice-sarsaparilla-tincture.json
+++ b/packages/data/data/ingredients/tincture/terra-spice-sarsaparilla-tincture.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Terra Spice Sarsaparilla Tincture",
+  "type": "tincture"
+}

--- a/packages/data/data/ingredients/wine/alvear-festival-pale-cream.json
+++ b/packages/data/data/ingredients/wine/alvear-festival-pale-cream.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Alvear Festival Pale Cream",
+  "type": "wine",
+  "categories": ["Sherry (Cream)"]
+}

--- a/packages/data/data/ingredients/wine/bonal-gentiane-quina.json
+++ b/packages/data/data/ingredients/wine/bonal-gentiane-quina.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Bonal Gentiane-Quina",
+  "type": "wine",
+  "categories": ["Quinquina"]
+}

--- a/packages/data/data/ingredients/wine/choya-kokuto-umeshu.json
+++ b/packages/data/data/ingredients/wine/choya-kokuto-umeshu.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Choya Kokuto Umeshu",
+  "type": "wine",
+  "categories": ["Plum wine"]
+}

--- a/packages/data/data/ingredients/wine/fausse-piste-garde-manger-syrah.json
+++ b/packages/data/data/ingredients/wine/fausse-piste-garde-manger-syrah.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Faussé Piste Garde Manger Syrah",
+  "type": "wine",
+  "categories": ["Red wine"]
+}

--- a/packages/data/data/ingredients/wine/gonzalez-byass-nectar-pedro-ximenez.json
+++ b/packages/data/data/ingredients/wine/gonzalez-byass-nectar-pedro-ximenez.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "González Byass Nectar Pedro Ximénez",
+  "type": "wine",
+  "categories": ["Sherry"]
+}

--- a/packages/data/data/ingredients/wine/gonzalez-byass-noe-pedro-ximenez.json
+++ b/packages/data/data/ingredients/wine/gonzalez-byass-noe-pedro-ximenez.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "González Byass Noé Pedro Ximénez",
+  "type": "wine",
+  "categories": ["Sherry"]
+}

--- a/packages/data/data/ingredients/wine/gonzalez-byass-pedro-ximenez.json
+++ b/packages/data/data/ingredients/wine/gonzalez-byass-pedro-ximenez.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "González Byass Pedro Ximénez",
+  "type": "wine",
+  "categories": ["Sherry"]
+}

--- a/packages/data/data/ingredients/wine/hidalgo-gobernador-oloroso.json
+++ b/packages/data/data/ingredients/wine/hidalgo-gobernador-oloroso.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Hidalgo Gobernador Oloroso",
+  "type": "wine",
+  "categories": ["Sherry (Oloroso)"]
+}

--- a/packages/data/data/ingredients/wine/saint-cosme-crozes-hermitage.json
+++ b/packages/data/data/ingredients/wine/saint-cosme-crozes-hermitage.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Saint Cosme Crozes-Hermitage",
+  "type": "wine",
+  "categories": ["Red wine"]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/aces-and-eights.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/aces-and-eights.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Aces and Eights",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Bittermens Xocolatl Mole Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Vanilla syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Galliano Ristretto",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Amaro Meletti",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "El Tesoro Reposado",
+      "type": "spirit",
+      "quantity": {
+        "amount": 2,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the orange twist over the drink, then place it in the drink."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Jarred Weigand"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 229
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/altimeter-julep.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/altimeter-julep.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Altimeter Julep",
+  "preparation": "built",
+  "served_on": "crushed ice",
+  "glassware": "julep",
+  "ingredients": [
+    {
+      "name": "Maple syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Clear Creek Douglas Fir Eau-de-Vie",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Yellow Chartreuse",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Clear Creek 8 Year Apple Brandy",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "El Tesoro Reposado",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Garnish with a mint bouquet and dried apple slice. Serve with a straw."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Jarred Weigand"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 229
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/artful-dodger.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/artful-dodger.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Artful Dodger",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Demerara syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Giffard banane du Brésil",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "El Dorado 15 Year",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Tariquet Classique VS Armagnac",
+      "type": "spirit",
+      "technique": {
+        "technique": "infusion",
+        "agent": "miso"
+      },
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Express the lemon twist over the drink and discard."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Tyson Buhler"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 229
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/backroads.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/backroads.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Backroads",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Vanilla syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Maple syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Amrut Peated Cask Strength",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Dupont Pommeau de Normandie",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Delord 25 Year Bas Armagnac",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Westward American Single Malt",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    }
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Michael Buonocore"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 229
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/backroads.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/backroads.json
@@ -31,7 +31,7 @@
     },
     {
       "name": "Dupont Pommeau de Normandie",
-      "type": "spirit",
+      "type": "liqueur",
       "quantity": {
         "amount": 0.5,
         "unit": "oz"

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/badlands-cobbler.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/badlands-cobbler.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Badlands Cobbler",
+  "preparation": "shaken",
+  "served_on": "crushed ice",
+  "glassware": "wine glass",
+  "ingredients": [
+    {
+      "name": "orange",
+      "type": "fruit",
+      "technique": [
+        {
+          "technique": "cut",
+          "type": "wheeled"
+        },
+        {
+          "technique": "muddled"
+        }
+      ],
+      "quantity": {
+        "amount": 1,
+        "unit": "unit"
+      }
+    },
+    {
+      "name": "Terra Spice Eucalyptus Extract",
+      "type": "tincture",
+      "quantity": {
+        "amount": 1,
+        "unit": "drop"
+      }
+    },
+    {
+      "name": "Demerara syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Giffard banane du Brésil",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "El Dorado 8 Year",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Fernet-Branca",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Carpano Antica Formula Vermouth",
+      "type": "wine",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Garnish with an orange slice and mint bouquet, and dust the top of the drink with powdered sugar. Serve with a straw."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Matthew Belanger"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 229
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/birds-of-prey.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/birds-of-prey.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Birds of Prey",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Bitter End Curry Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "drop"
+      }
+    },
+    {
+      "name": "Cane syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Ancho Reyes Ancho Chile Liqueur",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Scarlet Ibis Trinidad Rum",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Calle 23 Reposado",
+      "type": "spirit",
+      "technique": {
+        "technique": "infusion",
+        "agent": "dried mango"
+      },
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the orange twist over the drink, then place it in the drink."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Matthew Belanger"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 230
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/black-powder.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/black-powder.json
@@ -14,8 +14,8 @@
       }
     },
     {
-      "name": "House Orange Bitters",
-      "type": "bitter",
+      "name": "Orange bitters",
+      "type": "category",
       "quantity": {
         "amount": 1,
         "unit": "dash"

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/black-powder.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/black-powder.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Black Powder",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Angostura bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "House Orange Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Maple syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "St-Elizabeth Allspice Dram",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Tariquet Classique VS Armagnac",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Del Maguey Vida Mezcal",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Flame the orange twist over the drink, then place it in the drink."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Scott Teague"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 230
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/busy-earning.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/busy-earning.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Busy Earning",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Angostura bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Sarsaparilla Demerara Syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Laphroaig 10",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Cruzan Black Strap",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Redbreast 12 year Irish whiskey",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the orange twist over the drink, then place it in the drink."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Tyson Buhler"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 230
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/calypso-king.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/calypso-king.json
@@ -14,8 +14,8 @@
       }
     },
     {
-      "name": "House Orgeat",
-      "type": "syrup",
+      "name": "Orgeat",
+      "type": "category",
       "quantity": {
         "amount": 0.5,
         "unit": "tsp"

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/calypso-king.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/calypso-king.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Calypso King",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Bittermens' elemakule tiki bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "House Orgeat",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Pineapple Gum Syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Redbreast 12 year Irish whiskey",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Ron Navazos Palazzi Oloroso Cask Strength Rum",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the grapefruit twist over the drink, then place it in the drink."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Tyson Buhler"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 230
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/cashmere-thoughts.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/cashmere-thoughts.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Cashmere Thoughts",
+  "preparation": "stirred",
+  "served_on": "up",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Absinthe",
+      "type": "category",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Faretti Biscotti",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "González Byass Noé Pedro Ximénez",
+      "type": "wine",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Massenez Kirschwasser",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Gourry de Chadeville Overproof Cognac",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Express the lemon twist over the drink and discard."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Jarred Weigand"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 230
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/cipher.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/cipher.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Cipher",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Miracle Mile Redeye Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Absinthe",
+      "type": "category",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Yellow Chartreuse",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Galliano Ristretto",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Avua Amburana",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Navazos Palazzi Overseas Malt Whiskey",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the orange twist over the drink, then place it in the drink."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Sam Johnson"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 230
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/citadelle.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/citadelle.json
@@ -6,8 +6,8 @@
   "glassware": "old fashioned",
   "ingredients": [
     {
-      "name": "House Orange Bitters",
-      "type": "bitter",
+      "name": "Orange bitters",
+      "type": "category",
       "quantity": {
         "amount": 1,
         "unit": "dash"

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/citadelle.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/citadelle.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Citadelle",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "House Orange Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Absinthe",
+      "type": "category",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Honey syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Luxardo Maraschino Liqueur",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Bols Genever",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Rhine Hall Mango Brandy",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Express the lemon twist over the drink, then place it in the drink."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Tyson Buhler"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 231
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/cyrano.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/cyrano.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Cyrano",
+  "preparation": "built",
+  "served_on": "crushed ice",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "lime",
+      "type": "fruit",
+      "technique": [
+        {
+          "technique": "cut",
+          "type": "disc"
+        },
+        {
+          "technique": "muddled"
+        }
+      ],
+      "quantity": {
+        "amount": 1,
+        "unit": "unit"
+      }
+    },
+    {
+      "name": "Angostura bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Pineapple Gum Syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Planteray Stiggins' Fancy pineapple rum",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Cynar",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Rhum JM VSOP",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Garnish with a mint bouquet."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Jonnie Long"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 231
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/diamond-squad.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/diamond-squad.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Diamond Squad",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Bitter Truth Peach Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Pineapple Gum Syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Luxardo Maraschino Liqueur",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Anchor Hophead Vodka",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Bertoux",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Old Forester 100",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.25,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Express the lemon twist over the drink, then place it in the drink."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Matthew Belanger"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 231
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/dixieland-julep.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/dixieland-julep.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Dixieland Julep",
+  "preparation": "built",
+  "served_on": "crushed ice",
+  "glassware": "julep",
+  "ingredients": [
+    {
+      "name": "Pineapple Gum Syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Bittermens' New Orleans coffee liqueur",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Fernet-Branca",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lemon Hart 151",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Zacapa 23",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Pierre Ferrand 1840 Cognac",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Garnish with a dehydrated pineapple slice and mint bouquet, and grate some coffee over the top of the drink. Serve with a straw."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Tyson Buhler"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 231
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/double-dragon.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/double-dragon.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Double Dragon",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Bitter End Moroccan Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 2,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Port Syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Sombra Mezcal",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Yamazaki 12 Year",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the orange twist over the drink, then place it in the drink."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Al Sotack"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 231
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/empty-nester.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/empty-nester.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Empty Nester",
+  "preparation": "shaken",
+  "served_on": "crushed ice",
+  "glassware": "julep",
+  "ingredients": [
+    {
+      "name": "orange",
+      "type": "fruit",
+      "technique": [
+        {
+          "technique": "cut",
+          "type": "wheeled"
+        },
+        {
+          "technique": "muddled"
+        }
+      ],
+      "quantity": {
+        "amount": 1,
+        "unit": "unit"
+      }
+    },
+    {
+      "name": "lemon",
+      "type": "fruit",
+      "technique": [
+        {
+          "technique": "cut",
+          "type": "disc"
+        },
+        {
+          "technique": "muddled"
+        }
+      ],
+      "quantity": {
+        "amount": 1,
+        "unit": "unit"
+      }
+    },
+    {
+      "name": "Cinnamon syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Cyril Zangs 00 Apple Cider Eau-de-Vie",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Amaro Nonino",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Bonal Gentiane-Quina",
+      "type": "wine",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lustau Papirusa Manzanilla",
+      "type": "wine",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Insert the mint bouquet, orange half wheel, and apple slice into the ice; dust the top of the garnishes with powdered sugar and grated cinnamon."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Dave Anderson"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 231
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/event-horizon.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/event-horizon.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Event Horizon",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Orgeat Works Ltd macadamia nut syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Trader Vic's Macadamia Nut Liqueur",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Fernet Vallet",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Siete Leguas Añejo Tequila",
+      "type": "spirit",
+      "quantity": {
+        "amount": 2,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the orange twist over the drink, then place it in the drink."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Sam Johnson"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 233
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/false-summit.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/false-summit.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "False Summit",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Tempus Fugit crème de banane",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "González Byass Pedro Ximénez",
+      "type": "wine",
+      "quantity": {
+        "amount": 2,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Ron Navazos Palazzi Oloroso Cask Strength Rum",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Tyrconnell Single Malt",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Express the orange twist over the drink and discard."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Sam Johnson"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 233
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/get-free.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/get-free.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Get Free",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Bittermens' elemakule tiki bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Giffard crème de fruit de la passion",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Luxardo Maraschino Liqueur",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 2,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "El Dorado 15 Year",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Barrell Whiskey Batch 004",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the grapefruit twist over the drink, then place it in the drink."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Matthew Belanger"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 233
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/goldilocks.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/goldilocks.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Goldilocks",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Bittercube Jamaican Black Strap Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Cane syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Giffard banane du Brésil",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "CioCiaro",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Glen Grant 10 Year",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Hamilton Jamaican Pot Still Gold",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the orange twist over the drink, then place it in the drink."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Jillian Vose"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 233
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/hagakure.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/hagakure.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Hagakure",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Miracle Mile Yuzu Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 2,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Cane syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Yellow Chartreuse",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Chareau Aloe",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Caol Ila 12 Year",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Yamazaki 12 Year",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Express the lemon twist over the drink and discard."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Matthew Belanger"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 233
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/her-name-is-joy.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/her-name-is-joy.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Her Name Is Joy",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Demerara syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Galliano Ristretto",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Bénédictine",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Lustau Oloroso Sherry",
+      "type": "wine",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Highland Park 12 Year",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Appleton 21",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Express the orange twist over the drink and discard."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Sam Penton"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 233
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/highwayman.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/highwayman.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Highwayman",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Giffard crème de fruit de la passion",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Smith & Cross",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Galliano Ristretto",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 2,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Bowmore 12 Year",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Elijah Craig bourbon",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.25,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the orange twist over the drink, then place it in the drink."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Tyson Buhler"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 233
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/honor-amongst-thieves.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/honor-amongst-thieves.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Honor Amongst Thieves",
+  "preparation": "other",
+  "served_on": "up",
+  "glassware": "irish",
+  "ingredients": [
+    {
+      "name": "Terra Spice Birch Extract",
+      "type": "other",
+      "quantity": {
+        "amount": 3,
+        "unit": "drop"
+      }
+    },
+    {
+      "name": "Bitter Truth Aromatic Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 2,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Demerara syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Amaro Sfumato",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Cruzan Black Strap",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Saint Cosme Crozes-Hermitage",
+      "type": "wine",
+      "quantity": {
+        "amount": 3,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the orange twist over the drink and discard, then grate some nutmeg over the top."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Tyson Buhler"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 233
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/i-against-i.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/i-against-i.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "I Against I",
+  "preparation": "stirred",
+  "served_on": "up",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Strega",
+      "type": "liqueur",
+      "technique": {
+        "technique": "application",
+        "method": "rinse"
+      },
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Bitter End Jamaican Jerk Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Peychaud's bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 2,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Honey syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Compass Box Great King Street Glasgow Blend",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Hampden Estate 46",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Express the grapefruit twist over the drink and discard."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Matthew Belanger"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 233
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/ice-run-julep.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/ice-run-julep.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Ice Run Julep",
+  "preparation": "built",
+  "served_on": "crushed ice",
+  "glassware": "julep",
+  "ingredients": [
+    {
+      "name": "Honey syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Grand Marnier",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Forthave Spirits Marseille Amaro",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Eagle Rare Bourbon",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Château de Pellehaut Sélection Armagnac",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Garnish with a mint bouquet and orange half wheel. Serve with a straw."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Sam Johnson"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 235
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/lash-larue.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/lash-larue.json
@@ -6,8 +6,8 @@
   "glassware": "old fashioned",
   "ingredients": [
     {
-      "name": "House Orange Bitters",
-      "type": "bitter",
+      "name": "Orange bitters",
+      "type": "category",
       "quantity": {
         "amount": 1,
         "unit": "dash"

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/lash-larue.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/lash-larue.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Lash Larue",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "House Orange Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Cane syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Kümmel",
+      "type": "category",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Pierre Ferrand Dry Curaçao",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Reisetbauer Carrot Eau-de-Vie",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Rhum J.M Blanc 100",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Calle 23 Blanco",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.25,
+        "unit": "oz"
+      }
+    }
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Tim Miner"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 235
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/last-man-standing.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/last-man-standing.json
@@ -14,8 +14,8 @@
       }
     },
     {
-      "name": "House Orgeat",
-      "type": "syrup",
+      "name": "Orgeat",
+      "type": "category",
       "quantity": {
         "amount": 1,
         "unit": "tsp"

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/last-man-standing.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/last-man-standing.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Last Man Standing",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Angostura bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "House Orgeat",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Reisetbauer Carrot Eau-de-Vie",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Trader Vic's Macadamia Nut Liqueur",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Linie Aquavit",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Russel's Reserve Bourbon",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the orange twist over the drink, then place it in the drink."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Alex Jump"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 235
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/last-shadow.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/last-shadow.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Last Shadow",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Cinnamon syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Demerara syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Fernet-Branca",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Lemon Hart 151",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "El Dorado 15 Year",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the grapefruit twist over the drink, then place it in the drink."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Tyson Buhler"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 235
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/lone-star.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/lone-star.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Lone Star",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Terra Spice Root Beer Extract",
+      "type": "tincture",
+      "quantity": {
+        "amount": 1,
+        "unit": "drop"
+      }
+    },
+    {
+      "name": "Dale DeGroff's Pimento Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Vanilla syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Giffard Menthe-Pastille",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Bols Genever",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "John D. Taylor's Velvet Falernum",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Tapatio 110 Proof Blanco",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.75,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the orange twist over the drink, then place it in the drink."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Matthew Belanger"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 237
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/long-story-short.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/long-story-short.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Long Story Short",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Bitter Truth Jerry Thomas' Own Decanter Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Cinnamon syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Demerara syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Giffard crème de fruit de la passion",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Smith & Cross",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Old Forester Signature",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the orange twist over the drink, then place it in the drink."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Jeremy Oertel"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 237
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/lord-baltimore.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/lord-baltimore.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Lord Baltimore",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Maple syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Amaro di Angostura",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Giffard crème de pamplemousse rose",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Pikesville Rye",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "George Dickel Rye",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Jon Armstrong"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 237
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/lost-horizon.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/lost-horizon.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Lost Horizon",
+  "preparation": "stirred",
+  "served_on": "up",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Laphroaig 10",
+      "type": "spirit",
+      "technique": {
+        "technique": "application",
+        "method": "rinse"
+      },
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Fernet-Branca",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Giffard banane du Brésil",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 2,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Appleton 8",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Hine Rare VSOP Cognac",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the orange twist over the drink, then place it in the drink."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Tyson Buhler"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 237
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/match-grip-julep.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/match-grip-julep.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Match Grip Julep",
+  "preparation": "built",
+  "served_on": "crushed ice",
+  "glassware": "julep",
+  "ingredients": [
+    {
+      "name": "Bittermens Xocolatl Mole Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Demerara syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Marie Brizard White Crème de Cacao",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Branca Menta",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Appleton Signature",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Hine Rare VSOP Cognac",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Hamilton Jamaican Pot Still Black",
+      "type": "spirit",
+      "technique": {
+        "technique": "application",
+        "method": "top"
+      },
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    }
+  ],
+  "instructions": [
+    "Drizzle the Hamilton rum over the top. Garnish with a mint bouquet. Serve with a straw."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Jarred Weigand"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 237
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/midnight-oil.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/midnight-oil.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Midnight Oil",
+  "preparation": "shaken",
+  "served_on": "crushed ice",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "orange",
+      "type": "fruit",
+      "technique": [
+        {
+          "technique": "cut",
+          "type": "wheeled"
+        },
+        {
+          "technique": "muddled"
+        }
+      ],
+      "quantity": {
+        "amount": 1,
+        "unit": "unit"
+      }
+    },
+    {
+      "name": "Cinnamon syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Yellow Chartreuse",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Laird's Bonded Apple Brandy",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Faussé Piste Garde Manger Syrah",
+      "type": "wine",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Ramazzotti Amaro",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Garnish with a blackberry and grate some cinnamon over the top of the drink. Serve with a straw."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Tyson Buhler"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 237
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/minaseno.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/minaseno.json
@@ -6,8 +6,8 @@
   "glassware": "old fashioned",
   "ingredients": [
     {
-      "name": "House Orange Bitters",
-      "type": "bitter",
+      "name": "Orange bitters",
+      "type": "category",
       "quantity": {
         "amount": 1,
         "unit": "dash"

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/minaseno.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/minaseno.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Minaseno",
+  "preparation": "shaken",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "House Orange Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Vanilla syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Honey syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Hibiki Japanese Harmony",
+      "type": "spirit",
+      "technique": {
+        "technique": "infusion",
+        "agent": "shiitake"
+      },
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Calle 23 Reposado",
+      "type": "spirit",
+      "technique": {
+        "technique": "infusion",
+        "agent": "dried mango"
+      },
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the lemon and orange twists over the drink, then place them in the drink."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Tyson Buhler"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 237
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/monarch-julep.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/monarch-julep.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Monarch Julep",
+  "preparation": "built",
+  "served_on": "crushed ice",
+  "glassware": "julep",
+  "ingredients": [
+    {
+      "name": "Honey syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "CioCiaro",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "G.E. Massenez Crème de Pêche",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Peach Street Peach Brandy",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Hidalgo Gobernador Oloroso",
+      "type": "wine",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "J. Rieger Kansas City Whiskey",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Garnish with a mint bouquet and peach slice. Serve with a straw."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Tyson Buhler"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 237
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/mononoke.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/mononoke.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Mononoke",
+  "preparation": "shaken",
+  "served_on": "crushed ice",
+  "glassware": "collins",
+  "ingredients": [
+    {
+      "name": "lemon",
+      "type": "fruit",
+      "technique": [
+        {
+          "technique": "cut",
+          "type": "wheeled"
+        },
+        {
+          "technique": "muddled"
+        }
+      ],
+      "quantity": {
+        "amount": 1,
+        "unit": "unit"
+      }
+    },
+    {
+      "name": "Cane syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Dolin Génépy des Alpes",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lustau Amontillado Los Arcos Sherry",
+      "type": "wine",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Choya Kokuto Umeshu",
+      "type": "wine",
+      "quantity": {
+        "amount": 2,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Garnish with a lemon wheel, apple slice, and mint bouquet. Serve with a straw."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Shannon Tebay"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 237
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/mountain-of-light.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/mountain-of-light.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Mountain of Light",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Scrappy's Cardamom Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 3,
+        "unit": "drop"
+      }
+    },
+    {
+      "name": "Angostura bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Cane syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Rhine Hall Apple Brandy",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Leopold Bros. New York Sour Apple",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Cascahuin 48 Plata",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Garnish with an apple fan."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Matthew Belanger"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 237
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/moving-target.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/moving-target.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Moving Target",
+  "preparation": "stirred",
+  "served_on": "up",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Absinthe",
+      "type": "category",
+      "technique": {
+        "technique": "application",
+        "method": "rinse"
+      },
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Miracle Mile Redeye Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 2,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Demerara syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Rittenhouse Rye",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Jean-Luc Pasquet Marie-Framboise",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Pierre Ferrand 1840 Cognac",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Express the lemon twist over the drink and discard."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Jeremy Oertel"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 237
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/moving-target.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/moving-target.json
@@ -43,7 +43,7 @@
     },
     {
       "name": "Jean-Luc Pasquet Marie-Framboise",
-      "type": "spirit",
+      "type": "liqueur",
       "quantity": {
         "amount": 0.5,
         "unit": "oz"

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/no-look-pass.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/no-look-pass.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "No-Look Pass",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Simple syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Giffard Crème de Pêche de Vigne",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Massenez Garden Party",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Empirical Spirits Habanero",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Agave de Cortes Mezcal",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.25,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Garnish with a basil sprig."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Shannon Ponche"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 239
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/noble-one.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/noble-one.json
@@ -6,8 +6,8 @@
   "glassware": "old fashioned",
   "ingredients": [
     {
-      "name": "House Orange Bitters",
-      "type": "bitter",
+      "name": "Orange bitters",
+      "type": "category",
       "quantity": {
         "amount": 1,
         "unit": "dash"

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/noble-one.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/noble-one.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Noble One",
+  "preparation": "stirred",
+  "served_on": "up",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "House Orange Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Honey syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Rothman & Winter Orchard Apricot",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Quinta do Infantado White Porto",
+      "type": "wine",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Alvear Festival Pale Cream",
+      "type": "wine",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Express the lemon twist over the drink and discard."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Javel Taft"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 239
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/outlaw-country.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/outlaw-country.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Outlaw Country",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Angostura bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Vanilla syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Smith & Cross",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Amaro Averna",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Planteray Stiggins' Fancy pineapple rum",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Old Grand-Dad Bonded Bourbon",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the orange twist over the drink, then place it in the drink."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Tyson Buhler"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 239
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/paper-thin-hotel.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/paper-thin-hotel.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Paper Thin Hotel",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Angostura bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 2,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Demerara syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "G.E. Massenez Crème de Pêche",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Pierre Ferrand 1840 Cognac",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Rittenhouse Rye",
+      "type": "spirit",
+      "technique": {
+        "technique": "infusion",
+        "agent": "pistachio"
+      },
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the orange twist over the drink, then gently rub it around the rim of the glass. Express the lemon twist over the drink, then garnish with both twists."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Jarred Weigand"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 239
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/papi-chulep.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/papi-chulep.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Papi Chulep",
+  "preparation": "shaken",
+  "served_on": "crushed ice",
+  "glassware": "julep",
+  "ingredients": [
+    {
+      "name": "Mint leaves",
+      "type": "other",
+      "technique": {
+        "technique": "muddled"
+      },
+      "quantity": {
+        "amount": 7,
+        "unit": "unit"
+      }
+    },
+    {
+      "name": "Cane syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Grand Marnier",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Del Maguey Chichicapa Mezcal",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Calle 23 Blanco",
+      "type": "spirit",
+      "technique": {
+        "technique": "infusion",
+        "agent": "cacao nibs"
+      },
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Garnish with a mint bouquet. Serve with a straw."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Jon Armstrong"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 239
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/phantom-mood.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/phantom-mood.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Phantom Mood",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Miracle Mile Chocolate Chili Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Absinthe",
+      "type": "category",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Caffo Amaretto",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "González Byass Nectar Pedro Ximénez",
+      "type": "wine",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Springbank 10 Year",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Torres 15 Year Brandy",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the orange twist over the drink, then place it in the drink."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Jeremy Oertel"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 239
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/primrose.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/primrose.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Primrose",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "House Orange Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Simple syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Del Maguey Santo Domingo Albarradas Mezcal",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Italicus",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Domaine d'Espérance Blanche Armagnac",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Express the lemon twist over the drink, then place it in the drink."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Jarred Weigand"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 241
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/primrose.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/primrose.json
@@ -6,8 +6,8 @@
   "glassware": "old fashioned",
   "ingredients": [
     {
-      "name": "House Orange Bitters",
-      "type": "bitter",
+      "name": "Orange bitters",
+      "type": "category",
       "quantity": {
         "amount": 1,
         "unit": "dash"

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/pugilist.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/pugilist.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Pugilist",
+  "preparation": "shaken",
+  "served_on": "crushed ice",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Grapefruit",
+      "type": "fruit",
+      "technique": [
+        {
+          "technique": "cut",
+          "type": "wheeled"
+        },
+        {
+          "technique": "muddled"
+        }
+      ],
+      "quantity": {
+        "amount": 1,
+        "unit": "unit"
+      }
+    },
+    {
+      "name": "Pineapple Gum Syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Cruzan Single Barrel",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Fernet-Branca",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Amaro Averna",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Carpano Antica Formula Vermouth",
+      "type": "wine",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Salt",
+      "type": "other",
+      "quantity": {
+        "amount": 1,
+        "unit": "pinch"
+      }
+    }
+  ],
+  "instructions": [
+    "Garnish with a mint bouquet, raspberries, and blackberries, and dust the top of the drink with powdered sugar."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Tyson Buhler"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 241
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/queen-snake.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/queen-snake.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Queen Snake",
+  "preparation": "built",
+  "served_on": "crushed ice",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "lime",
+      "type": "fruit",
+      "technique": [
+        {
+          "technique": "cut",
+          "type": "disc"
+        },
+        {
+          "technique": "muddled"
+        }
+      ],
+      "quantity": {
+        "amount": 1,
+        "unit": "unit"
+      }
+    },
+    {
+      "name": "Marie Brizard White Crème de Cacao",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Giffard Lichi Li",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 2,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Clear Creek Douglas Fir Eau-de-Vie",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Cobrafire Eau-de-Vie de Raisin",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Shannon Tebay"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 241
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/recortador.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/recortador.json
@@ -14,8 +14,8 @@
       }
     },
     {
-      "name": "House Orange Bitters",
-      "type": "bitter",
+      "name": "Orange bitters",
+      "type": "category",
       "quantity": {
         "amount": 1,
         "unit": "dash"

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/recortador.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/recortador.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Recortador",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Bittermens Hellfire Habanero Shrub",
+      "type": "bitter",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "House Orange Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Pineapple Gum Syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Green Chartreuse",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "St. George Green Chile Vodka",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Del Maguey San Luis del Rio Mezcal",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Tapatio 110 Proof Blanco",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.25,
+        "unit": "oz"
+      }
+    }
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Matthew Belanger"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 241
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/rose-parade.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/rose-parade.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "Crème de Rose",
-      "type": "liqueur",
+      "type": "category",
       "quantity": {
         "amount": 1,
         "unit": "tsp"

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/rose-parade.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/rose-parade.json
@@ -30,8 +30,8 @@
       }
     },
     {
-      "name": "House Orange Bitters",
-      "type": "bitter",
+      "name": "Orange bitters",
+      "type": "category",
       "quantity": {
         "amount": 1,
         "unit": "dash"

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/rose-parade.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/rose-parade.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Rose Parade",
+  "preparation": "stirred",
+  "served_on": "up",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Absinthe",
+      "type": "category",
+      "technique": {
+        "technique": "application",
+        "method": "rinse"
+      },
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Emile Pernot Fraise de Bois",
+      "type": "liqueur",
+      "technique": {
+        "technique": "application",
+        "method": "rinse"
+      },
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "House Orange Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Combier Crème de Rose",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Kappa Pisco",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Cocchi Americano",
+      "type": "wine",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Campo de Encanto Pisco",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Jeremy Oertel"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 241
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/rose-parade.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/rose-parade.json
@@ -38,7 +38,7 @@
       }
     },
     {
-      "name": "Combier Crème de Rose",
+      "name": "Crème de Rose",
       "type": "liqueur",
       "quantity": {
         "amount": 1,

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/sasaki-garden.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/sasaki-garden.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Sasaki Garden",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "House Orange Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Rothman & Winter Orchard Apricot",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Caffo Amaretto",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 2,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Avua Amburana",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Nikka Coffey Grain Whisky",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Express the lemon twist over the drink, then place it in the drink."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Sam Johnson"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 241
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/sasaki-garden.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/sasaki-garden.json
@@ -6,8 +6,8 @@
   "glassware": "old fashioned",
   "ingredients": [
     {
-      "name": "House Orange Bitters",
-      "type": "bitter",
+      "name": "Orange bitters",
+      "type": "category",
       "quantity": {
         "amount": 1,
         "unit": "dash"

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/sazerac-standing-room.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/sazerac-standing-room.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Sazerac (Standing Room)",
+  "preparation": "stirred",
+  "served_on": "up",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Absinthe",
+      "type": "category",
+      "technique": {
+        "technique": "application",
+        "method": "rinse"
+      },
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Bitter Truth Celery Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Cane syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Old Grand-Dad 114 Proof Bourbon",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Giffard Rhubarb",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Busnel VSOP Calvados",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Matthew Belanger"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 241
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/sea-legs.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/sea-legs.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Sea Legs",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Whiskey Barrel-Aged Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Reisetbauer Hazelnut Eau-de-Vie",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Lost Spirits Navy Style",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Kalani Coconut Liqueur",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Scarlet Ibis Trinidad Rum",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Barbancourt 8 Year",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Express the lemon twist over the drink and discard."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Tyson Buhler"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 241
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/shadow-box.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/shadow-box.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Shadow Box",
+  "preparation": "stirred",
+  "served_on": "up",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Bittermens Xocolatl Mole Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Orgeat Works Ltd macadamia nut syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Giffard Crème de Framboise",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Del Bac Distiller's Cut",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Château de Pellehaut Sélection Armagnac",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the orange twist over the drink, then place it in the drink."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Shannon Tebay"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 241
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/smoking-jacket.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/smoking-jacket.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Smoking Jacket",
+  "preparation": "stirred",
+  "served_on": "up",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Laphroaig 10",
+      "type": "spirit",
+      "technique": {
+        "technique": "application",
+        "method": "rinse"
+      },
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Angostura bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Peychaud's bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 3,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Demerara syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Busnel VSOP Calvados",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Hine Rare VSOP Cognac",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Jon Armstrong"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 241
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/stoned-love.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/stoned-love.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Stoned Love",
+  "preparation": "shaken",
+  "served_on": "crushed ice",
+  "glassware": "wine glass",
+  "ingredients": [
+    {
+      "name": "Simple syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Giffard Menthe-Pastille",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "St. George Absinthe Verte",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Clear Creek Pear Brandy",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Absentroux",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 3,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Short shake all the ingredients with ice for about 5 seconds, then strain into a tulip glass.",
+    "Fill the glass with crushed ice.",
+    "Garnish with the mint bouquet and spray some absinthe over the top of the drink.",
+    "Serve with a straw."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Shannon Tebay"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 241
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/strip-solitaire.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/strip-solitaire.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Strip Solitaire",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Bittermens' elemakule tiki bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Angostura bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 2,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Cane syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Giffard Caribbean Pineapple",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Evan Williams Bottled-in-Bond",
+      "type": "spirit",
+      "quantity": {
+        "amount": 2,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Garnish with the dehydrated pineapple wedge."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Alex Jump"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 241
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/sweet-dynamite.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/sweet-dynamite.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Sweet Dynamite",
+  "preparation": "stirred",
+  "served_on": "crushed ice",
+  "glassware": "julep",
+  "ingredients": [
+    {
+      "name": "Cinnamon syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Lemon Hart 151",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Giffard crème de fruit de la passion",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Appleton 8",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Krogstad Aquavit",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Combine all the ingredients in a julep tin and fill the tin about halfway with crushed ice.",
+    "Holding the tin by the rim, stir, churning the ice as you go, for about 10 seconds.",
+    "Add more crushed ice to fill the tin about two-thirds full and stir until the tin is completely frosted.",
+    "Add more ice to form a cone above the rim.",
+    "Garnish with the mint bouquet and shave some chocolate over the top of the drink.",
+    "Serve with a straw."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Shannon Tebay"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 243
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/the-lonesome-crowded-west.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/the-lonesome-crowded-west.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "The Lonesome Crowded West",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Angostura bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Giffard crème de fruit de la passion",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Old Grand-Dad 114 Proof Bourbon",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Amaro Nonino",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Ron del Barrilito 3 Star",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Express the grapefruit twist over the drink and discard."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Matthew Belanger"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 235
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/the-manticore.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/the-manticore.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "The Manticore",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Peychaud's bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Cinnamon syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Giffard Menthe-Pastille",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "John D. Taylor's Velvet Falernum",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Beefeater London Dry Gin",
+      "type": "spirit",
+      "quantity": {
+        "amount": 2,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Express the lemon twist over the drink, then place it in the drink."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Scott Teague"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 237
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/the-whiskey-agreement.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/the-whiskey-agreement.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "The Whiskey Agreement",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Angostura bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Cinnamon syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "St-Elizabeth Allspice Dram",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Old Grand-Dad 114 Proof Bourbon",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Tyrconnell Single Malt",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Highland Park 12 Year",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Hibiki Japanese Harmony",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the orange twist over the drink, then gently rub it around the rim of the glass.",
+    "Express the lemon twist over the drink, then garnish with both twists."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Scott Teague"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 245
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/thieves-in-the-night.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/thieves-in-the-night.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Thieves in the Night",
+  "preparation": "stirred",
+  "served_on": "crushed ice",
+  "glassware": "julep",
+  "ingredients": [
+    {
+      "name": "Maple syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Braulio",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Sombra Mezcal",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "St. George Terroir Gin",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Combine all the ingredients in a julep tin and fill the tin about halfway with crushed ice.",
+    "Holding the tin by the rim, stir, churning the ice as you go, for about 10 seconds.",
+    "Add more crushed ice to fill the tin about two-thirds full and stir until the tin is completely frosted.",
+    "Add more ice to form a cone above the rim.",
+    "Garnish with the mint bouquet and shave some chocolate over the top of the drink.",
+    "Serve with a straw."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Jarred Weigand"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 243
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/tradition.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/tradition.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Tradition",
+  "preparation": "other",
+  "served_on": "up",
+  "glassware": "irish",
+  "ingredients": [
+    {
+      "name": "Angostura bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Honey syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Cinnamon syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Water",
+      "type": "other",
+      "technique": {
+        "technique": "temperature",
+        "method": "boiling"
+      },
+      "quantity": {
+        "amount": 3,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Galliano Ristretto",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Lemorton Selection Calvados Domfrontais",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Caol Ila 12 Year",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Combine all the ingredients except the water in an Irish coffee mug.",
+    "Add the boiling water.",
+    "Express the orange twist over the drink and discard.",
+    "Garnish with the cinnamon stick."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Tyson Buhler"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 243
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/tripwire.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/tripwire.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Tripwire",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Bittermens Xocolatl Mole Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 2,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Pineapple Gum Syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Crème de Cacao",
+      "type": "category",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Smith & Cross",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Ron del Barrilito 3 Star",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Kilkerran 12 Year",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Express the lemon twist over the drink, then place it in the drink."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Shannon Tebay"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 243
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/uncanny-valley.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/uncanny-valley.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Uncanny Valley",
+  "preparation": "stirred",
+  "served_on": "up",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Reisetbauer Carrot Eau-de-Vie",
+      "type": "spirit",
+      "technique": {
+        "technique": "application",
+        "method": "rinse"
+      },
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Bitter Truth Celery Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Agave syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Ransom Old Tom",
+      "type": "spirit",
+      "technique": {
+        "technique": "infusion",
+        "agent": "coriander"
+      },
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Tequila Ocho Reposado",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "St. George Dry Rye Reposado",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Express the lemon twist over the drink, then place it in the drink."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Dave Anderson"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 243
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/unforgiven.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/unforgiven.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Unforgiven",
+  "preparation": "stirred",
+  "served_on": "up",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Laphroaig 10",
+      "type": "spirit",
+      "technique": {
+        "technique": "application",
+        "method": "rinse"
+      },
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Peychaud's bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 2,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Angostura bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 2,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Demerara syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Rhine Hall Cherry Brandy",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Brugal 1888",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Drambuie",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Pierre Ferrand 1840 Cognac",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Monkey Shoulder Blended Scotch",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Express the orange twist over the drink and discard."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Jon Feuersanger"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 245
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/vantage-point.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/vantage-point.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Vantage Point",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Italicus",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Bertoux",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Suntory Toki",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Javel Taft"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 245
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/vaquero.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/vaquero.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Vaquero",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Demerara syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Marie Brizard White Crème de Cacao",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Calle 23 Reposado",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Del Maguey Chichicapa Mezcal",
+      "type": "spirit",
+      "technique": {
+        "technique": "infusion",
+        "agent": "corn husk"
+      },
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the orange twist over the drink, then place it in the drink."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Tyson Buhler"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 245
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/verona-cobbler.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/verona-cobbler.json
@@ -14,8 +14,8 @@
       }
     },
     {
-      "name": "House Orgeat",
-      "type": "syrup",
+      "name": "Orgeat",
+      "type": "category",
       "quantity": {
         "amount": 0.5,
         "unit": "oz"

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/verona-cobbler.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/verona-cobbler.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Verona Cobbler",
+  "preparation": "built",
+  "served_on": "crushed ice",
+  "glassware": "wine glass",
+  "ingredients": [
+    {
+      "name": "rose water",
+      "type": "other",
+      "quantity": {
+        "amount": 3,
+        "unit": "drop"
+      }
+    },
+    {
+      "name": "House Orgeat",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Massenez Kirsch Vieux",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Domaine d'Espérance Blanche Armagnac",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Sparkling wine",
+      "type": "category",
+      "quantity": {
+        "amount": 3,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Pour the sparkling wine into a tulip glass.",
+    "Add the remaining ingredients and fill the glass with crushed ice.",
+    "Express the grapefruit twist over the drink and insert it into the ice.",
+    "Serve with a straw."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Sam Johnson"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 245
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/victory-lap.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/victory-lap.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Victory Lap",
+  "preparation": "stirred",
+  "served_on": "up",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Absinthe",
+      "type": "category",
+      "quantity": {
+        "amount": 2,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Vanilla syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Merlet Crème de Fraise des Bois",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Laurent Cazottes 72 Tomatoes",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Dolin Dry Vermouth de Chambéry",
+      "type": "wine",
+      "quantity": {
+        "amount": 2.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Express the lemon twist over the drink and discard."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Matthew Belanger"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 245
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/wall-of-sound.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/wall-of-sound.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Wall of Sound",
+  "preparation": "stirred",
+  "served_on": "up",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Laphroaig 10",
+      "type": "spirit",
+      "technique": {
+        "technique": "application",
+        "method": "rinse"
+      },
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Bittermens' elemakule tiki bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 2,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Cane syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Hampden Estate Rum Fire",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Kalani Coconut Liqueur",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Bowmore 12 Year",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Elijah Craig bourbon",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Express the grapefruit twist over the drink and discard."],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Shannon Tebay"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 245
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/warspite.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/warspite.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Warspite",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "St-Elizabeth Allspice Dram",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Clear Creek Blue Plum Brandy",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Plymouth Sloe Gin",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Aperol",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Plymouth Gin",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.25,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the orange twist over the drink, then place it in the drink."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Matthew Belanger"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 245
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/wheelwriter-no-10.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/wheelwriter-no-10.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Wheelwriter No. 10",
+  "preparation": "stirred",
+  "served_on": "up",
+  "glassware": "nick & nora",
+  "ingredients": [
+    {
+      "name": "Absinthe",
+      "type": "category",
+      "technique": {
+        "technique": "application",
+        "method": "rinse"
+      },
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Demerara syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Marie Brizard White Crème de Cacao",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Famous Grouse",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Campari",
+      "type": "liqueur",
+      "technique": {
+        "technique": "infusion",
+        "agent": "coffee bean"
+      },
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Busnel VSOP Calvados",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Emily Hoon"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 245
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/year-of-the-trees.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/year-of-the-trees.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "../../../../../schemas/recipe.schema.json",
+  "name": "Year of the Trees",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Terra Spice Sarsaparilla Tincture",
+      "type": "tincture",
+      "quantity": {
+        "amount": 1,
+        "unit": "drop"
+      }
+    },
+    {
+      "name": "Angostura bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Demerara syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Mal Bien Espadin Mezcal",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Amaro Nonino",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Knob Creek 100",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Express the orange twist over the drink, then place it in the drink."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Matthew Belanger"
+    },
+    {
+      "relation": "bar",
+      "source": "Death & Co",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "death-co-welcome-home",
+      "page": 245
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds 75 recipes from chapter 4 of *Death & Co: Welcome Home*
- Includes supporting ingredient files (spirits, liqueurs, bitters, wines, syrups, tinctures) and new categories (Kümmel, Basil liqueur, Rose liqueur, Plum wine, Strawberry liqueur, Brandy (Peach), Armagnac, Whisky (Peated))
- Reclassifies all existing Armagnac ingredients from "Brandy (Grapes)" to the new "Armagnac" category
- Adds "Whisky (Peated)" as a parent category of "Whisky (Islay Scotch)"
- HOT DREAMS skipped — recipe is incomplete in the book

## Test plan

- [x] `yarn check-data` passes