### PR TITLE
chore: replace vite-tsconfig-paths with native Vite option

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
           - '@next/*'
           - next-*
           - '@vitejs/*'
-          - vite-tsconfig-paths
           - nuqs
       react:
         patterns:

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "imports": {
-    "#/*": "./src/*"
+    "#/*": "./*"
   },
   "scripts": {
     "dev": "next dev --turbopack",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "oxfmt": "^0.45.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.58.2",
-    "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.4"
   },
   "nano-staged": {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 import react from '@vitejs/plugin-react';
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { coverageConfigDefaults, defineConfig } from 'vitest/config';
 
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
@@ -57,5 +56,8 @@ export default defineConfig({
       },
     ],
   },
-  plugins: [tsconfigPaths(), react()],
+  resolve: {
+    tsconfigPaths: true,
+  },
+  plugins: [react()],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2889,7 +2889,6 @@ __metadata:
     oxfmt: "npm:^0.45.0"
     typescript: "npm:^6.0.3"
     typescript-eslint: "npm:^8.58.2"
-    vite-tsconfig-paths: "npm:^6.1.1"
     vitest: "npm:^4.1.4"
   languageName: unknown
   linkType: soft
@@ -3023,7 +3022,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.0, debug@npm:^4.4.3":
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.0, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -3997,13 +3996,6 @@ __metadata:
     define-properties: "npm:^1.2.1"
     gopd: "npm:^1.0.1"
   checksum: 10c0/9d156f313af79d80b1566b93e19285f481c591ad6d0d319b4be5e03750d004dde40a39a0f26f7e635f9007a3600802f53ecd85a759b86f109e80a5f705e01846
-  languageName: node
-  linkType: hard
-
-"globrex@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "globrex@npm:0.1.2"
-  checksum: 10c0/a54c029520cf58bda1d8884f72bd49b4cd74e977883268d931fd83bcbd1a9eb96d57c7dbd4ad80148fb9247467ebfb9b215630b2ed7563b2a8de02e1ff7f89d1
   languageName: node
   linkType: hard
 
@@ -6603,20 +6595,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsconfck@npm:^3.0.3":
-  version: 3.1.6
-  resolution: "tsconfck@npm:3.1.6"
-  peerDependencies:
-    typescript: ^5.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  bin:
-    tsconfck: bin/tsconfck.js
-  checksum: 10c0/269c3c513540be44844117bb9b9258fe6f8aeab026d32aeebf458d5299125f330711429dbb556dbf125a0bc25f4a81e6c24ac96de2740badd295c3fb400f66c4
-  languageName: node
-  linkType: hard
-
 "tsconfig-paths@npm:^3.15.0":
   version: 3.15.0
   resolution: "tsconfig-paths@npm:3.15.0"
@@ -6879,19 +6857,6 @@ __metadata:
   dependencies:
     punycode: "npm:^2.1.0"
   checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
-  languageName: node
-  linkType: hard
-
-"vite-tsconfig-paths@npm:^6.1.1":
-  version: 6.1.1
-  resolution: "vite-tsconfig-paths@npm:6.1.1"
-  dependencies:
-    debug: "npm:^4.1.1"
-    globrex: "npm:^0.1.2"
-    tsconfck: "npm:^3.0.3"
-  peerDependencies:
-    vite: "*"
-  checksum: 10c0/5e61080991418fefa08c5b98995cdcada4931ae01ac97ef9e2ee941051f61b76890a6e7ba48bed3b2a229ec06fef33a06621bba4ce457b3f4233ad31dc0c1d1b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Removes the `vite-tsconfig-paths` plugin in favor of Vite's native `resolve.tsconfigPaths: true` option
- Fixes incorrect `imports` mapping in `apps/web/package.json` (`./src/*` -> `./*` — there is no `src/` directory)
- Removes the dependency from `package.json`, `yarn.lock`, and `.github/dependabot.yml`

## Test plan
- [x] `yarn vitest --run` — all 330 tests pass
- [x] No more "vite-tsconfig-paths" deprecation warning