### PR TITLE
feat: add Coconuts & Carnage book with 5 preview recipes

### DIFF
--- a/packages/data/data/ingredients/syrup/bg-reynolds-falernum.json
+++ b/packages/data/data/ingredients/syrup/bg-reynolds-falernum.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "BG Reynolds Falernum",
+  "type": "syrup",
+  "categories": ["Falernum syrup"]
+}

--- a/packages/data/data/recipes/book/coconuts-and-carnage/_source.json
+++ b/packages/data/data/recipes/book/coconuts-and-carnage/_source.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../../schemas/book.schema.json",
+  "name": "Coconuts & Carnage",
+  "link": "https://www.wonkpress.com/products/coconuts-carnage",
+  "description": "Coconuts & Carnage: Fifty Fiery Originals from the Emerald City is a battle-tested collection of 50 modern tropical cocktails by Seattle-based tiki bartender Justin Wojslaw, built on classic structure. From disciplined tributes to the tiki canon to originals that lean into fire and funk, every recipe hits hard and holds up in service."
+}

--- a/packages/data/data/recipes/book/coconuts-and-carnage/cape-town-cooler.json
+++ b/packages/data/data/recipes/book/coconuts-and-carnage/cape-town-cooler.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Cape Town Cooler",
+  "preparation": "shaken",
+  "served_on": "crushed ice",
+  "glassware": "snifter",
+  "ingredients": [
+    {
+      "name": "Angostura bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 2,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Vanilla syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Cinnamon syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lime juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Grapefruit juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Mr. Black coffee liqueur",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Appleton Signature",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Don Q Gold Rum",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Combine all ingredients into a shaker tin and shake with cracked or pebble ice.",
+    "Dump into a snifter glass.",
+    "Garnish with a mint sprig and a spent lime shell topped with espresso beans."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Justin Wojslaw"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "Coconuts & Carnage",
+      "page": 23
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/coconuts-and-carnage/krakatoa-punch.json
+++ b/packages/data/data/recipes/book/coconuts-and-carnage/krakatoa-punch.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Krakatoa Punch",
+  "preparation": "shaken",
+  "served_on": "crushed ice",
+  "glassware": "collins",
+  "ingredients": [
+    {
+      "name": "Angostura bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 2,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Orange juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Grapefruit juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "BG Reynolds Falernum",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lime juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Giffard abricot du Roussillon",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Mr. Black coffee liqueur",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Hamilton 151 Demerara rum",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Combine all ingredients into a shaker tin and shake with cracked or pebble ice.",
+    "Dump into a zombie glass or a tiki mug.",
+    "Garnish with a cinnamon stick."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Justin Wojslaw"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "Coconuts & Carnage",
+      "page": 47
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/coconuts-and-carnage/macadamia-nut-chi-chi.json
+++ b/packages/data/data/recipes/book/coconuts-and-carnage/macadamia-nut-chi-chi.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Macadamia Nut Chi-Chi",
+  "preparation": "shaken",
+  "served_on": "crushed ice",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Lemon juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Cream of coconut",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Pineapple juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Trader Vic's Macadamia Nut Liqueur",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Planteray Original Dark",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Combine all ingredients in a shaker tin and shake with cracked or pebble ice.",
+    "Dump into a mai tai glass.",
+    "Garnish with a lemon wheel and a mint sprig."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Justin Wojslaw"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "Coconuts & Carnage",
+      "page": 48
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/coconuts-and-carnage/pharaohs-curse.json
+++ b/packages/data/data/recipes/book/coconuts-and-carnage/pharaohs-curse.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Pharaoh's Curse",
+  "preparation": "shaken",
+  "served_on": "crushed ice",
+  "glassware": "snifter",
+  "ingredients": [
+    {
+      "name": "Honey syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lime juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lemon juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Luxardo Maraschino Liqueur",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Giffard abricot du Roussillon",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Pierre Ferrand Dry Curaçao",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Smith & Cross",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Planteray Stiggins' Fancy pineapple rum",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Combine all ingredients into a shaker tin and shake with cracked or pebble ice.",
+    "Dump into a snifter.",
+    "Garnish with lemon and lime wheels and a cocktail cherry."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Justin Wojslaw"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "Coconuts & Carnage",
+      "page": 63
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/coconuts-and-carnage/texas-tatsu-ya.json
+++ b/packages/data/data/recipes/book/coconuts-and-carnage/texas-tatsu-ya.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Texas Tatsu-Ya",
+  "preparation": "shaken",
+  "served_on": "crushed ice",
+  "glassware": "snifter",
+  "ingredients": [
+    {
+      "name": "Pineapple juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Cream of coconut",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lemon juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "St. George Raspberry liqueur",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Beefeater London Dry Gin",
+      "type": "spirit",
+      "quantity": {
+        "amount": 2,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Combine all ingredients into a shaker tin and shake with cracked or pebble ice.",
+    "Dump into a snifter glass.",
+    "Garnish with a lemon wheel and a mint sprig."
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Justin Wojslaw"
+    }
+  ],
+  "refs": [
+    {
+      "type": "book",
+      "title": "Coconuts & Carnage",
+      "page": 93
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds book source for **Coconuts & Carnage: Fifty Fiery Originals from the Emerald City** by Justin Wojslaw (Wonk Press, 2026)
- Creates 5 recipes extracted from the [publisher preview](https://www.wonkpress.com/products/coconuts-carnage): Cape Town Cooler, Krakatoa Punch, Macadamia Nut Chi-Chi, Pharaoh's Curse, and Texas Tatsu-Ya
- Adds new ingredient: BG Reynolds Falernum (non-alcoholic falernum syrup)

## Test plan
- [x] `yarn check-data` passes