### PR TITLE
feat: add recipes from YouTube videos (week of 2026-04-20)

### DIFF
--- a/packages/data/data/ingredients/spirit/okolehao.json
+++ b/packages/data/data/ingredients/spirit/okolehao.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Okolehao",
+  "type": "spirit"
+}

--- a/packages/data/data/recipes/youtube-channel/anders-erickson/morning-glory-fizz.json
+++ b/packages/data/data/recipes/youtube-channel/anders-erickson/morning-glory-fizz.json
@@ -80,6 +80,11 @@
     {
       "type": "youtube",
       "videoId": "t6qElzw9Jic"
+    },
+    {
+      "type": "youtube",
+      "videoId": "qKgCw8f50BQ",
+      "start": 487
     }
   ]
 }

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/clara-bow.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/clara-bow.json
@@ -63,6 +63,11 @@
     {
       "type": "youtube",
       "videoId": "P5qAYo2lvtQ"
+    },
+    {
+      "type": "youtube",
+      "videoId": "qKgCw8f50BQ",
+      "start": 950
     }
   ]
 }

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/panacea.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/panacea.json
@@ -50,6 +50,15 @@
     {
       "type": "youtube",
       "videoId": "z0_980tk3Lw"
+    },
+    {
+      "type": "youtube",
+      "videoId": "l3AVZXBy_fg"
+    },
+    {
+      "type": "youtube",
+      "videoId": "qKgCw8f50BQ",
+      "start": 264
     }
   ]
 }

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/the-beehive-old-fashioned.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/the-beehive-old-fashioned.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "The Beehive Old Fashioned",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "servings": 6,
+  "ingredients": [
+    {
+      "name": "Orange bitters",
+      "type": "category",
+      "quantity": {
+        "amount": 10,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Angostura bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 16,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Cinnamon syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 2.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Old Tom Gin",
+      "type": "category",
+      "quantity": {
+        "amount": 8,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Whisky (Scotch)",
+      "type": "category",
+      "quantity": {
+        "amount": 8,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Coat the inside of a bottle with melted beeswax.",
+    "Combine all ingredients in the beeswax-coated bottle and stir to mix.",
+    "Pour 3 oz per serving over a big rock in an old fashioned glass.",
+    "Garnish with an orange twist."
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "-R0Wcpvwol8"
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/the-oriental.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/the-oriental.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "The Oriental",
+  "preparation": "shaken",
+  "served_on": "up",
+  "glassware": "coupe",
+  "ingredients": [
+    {
+      "name": "Lime juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Triple Sec",
+      "type": "category",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Sweet vermouth",
+      "type": "category",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Whiskey (Rye)",
+      "type": "category",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "qKgCw8f50BQ",
+      "start": 56
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/make-and-drink/bali-hai.json
+++ b/packages/data/data/recipes/youtube-channel/make-and-drink/bali-hai.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../../../../schemas/recipe.schema.json",
   "name": "Bali Hai",
-  "preparation": "shaken",
-  "served_on": "ice cubes",
+  "preparation": "flash blended",
+  "served_on": "crushed ice",
   "glassware": "collins",
   "ingredients": [
     {

--- a/packages/data/data/recipes/youtube-channel/make-and-drink/bali-hai.json
+++ b/packages/data/data/recipes/youtube-channel/make-and-drink/bali-hai.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Bali Hai",
+  "preparation": "shaken",
+  "served_on": "ice cubes",
+  "glassware": "collins",
+  "ingredients": [
+    {
+      "name": "Lime juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lemon juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Simple syrup",
+      "type": "syrup",
+      "brix": 66,
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Blended Lightly-aged Rum",
+      "type": "category",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Okolehao",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Champagne",
+      "type": "category",
+      "technique": {
+        "technique": "application",
+        "method": "top"
+      },
+      "quantity": {
+        "amount": 2,
+        "unit": "oz"
+      }
+    }
+  ],
+  "attributions": [
+    {
+      "relation": "bar",
+      "source": "Hanalei Plantation Hotel",
+      "location": "Hanalei, HI"
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "plrC-2wSJfI"
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/make-and-drink/poco-coco-loco.json
+++ b/packages/data/data/recipes/youtube-channel/make-and-drink/poco-coco-loco.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Poco Coco Loco",
+  "preparation": "flash blended",
+  "served_on": "crushed ice",
+  "glassware": "tiki",
+  "ingredients": [
+    {
+      "name": "Cream of coconut",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lime juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Coconut water",
+      "type": "other",
+      "quantity": {
+        "amount": 2,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Bénédictine",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Black blended Overproof Rum",
+      "type": "category",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Blended Lightly-aged Rum",
+      "type": "category",
+      "quantity": {
+        "amount": 1.25,
+        "unit": "oz"
+      }
+    }
+  ],
+  "attributions": [
+    {
+      "relation": "bar",
+      "source": "Trader Vic's"
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "O4jJvMZZBi8"
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/make-and-drink/white-bat.json
+++ b/packages/data/data/recipes/youtube-channel/make-and-drink/white-bat.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "White Bat",
+  "preparation": "built",
+  "served_on": "ice cubes",
+  "glassware": "collins",
+  "ingredients": [
+    {
+      "name": "Whole milk",
+      "type": "other",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Kahlua Original coffee liqueur",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Blended Lightly-aged Rum",
+      "type": "category",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Coca-Cola",
+      "type": "soda",
+      "quantity": {
+        "amount": 3,
+        "unit": "oz"
+      }
+    }
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Simon Ford"
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "NaSi7SuwXFM"
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/truffles-on-the-rocks/the-rebujito.json
+++ b/packages/data/data/recipes/youtube-channel/truffles-on-the-rocks/the-rebujito.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "The Rebujito",
+  "preparation": "built",
+  "served_on": "ice cubes",
+  "glassware": "collins",
+  "ingredients": [
+    {
+      "name": "Mint leaves",
+      "type": "other",
+      "quantity": {
+        "amount": 8,
+        "unit": "unit"
+      }
+    },
+    {
+      "name": "Sherry (Fino)",
+      "type": "category",
+      "quantity": {
+        "amount": 2.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "7 Up",
+      "type": "soda",
+      "quantity": {
+        "amount": 4,
+        "unit": "oz"
+      }
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "t8ZNLNtc1rE"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Process new YouTube videos from issue #242.

**New recipes (6):**
- The Oriental (Educated Barfly)
- The Beehive Old Fashioned (Educated Barfly) — batch recipe, 6 servings
- Bali Hai (Make and Drink) — from Hanalei Plantation Hotel, 1964
- Poco Coco Loco (Make and Drink) — lost Trader Vic recipe
- White Bat (Make and Drink) — by Simon Ford
- The Rebujito (Truffles On The Rocks)

**Updated refs (3):**
- Panacea — added 2 video refs
- Clara Bow — added 1 video ref
- Morning Glory Fizz — added 1 video ref

**New ingredient:**
- Okolehao (Hawaiian ti root spirit, auto-created by validator)

**Skipped:**
- Spike's Breezeway "The Tiki That Led to 300" — tiki art/carving, not a recipe

Closes #242