### PR TITLE
feat: add recipes from YouTube videos (week of 2026-04-27)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "vitest": "^4.1.5"
   },
   "nano-staged": {
-    "*": "yarn oxfmt --no-error-on-unmatched-pattern",
-    "*.m?[jt]sx?": "yarn eslint . --fix"
+    "*": "oxfmt --no-error-on-unmatched-pattern",
+    "*.m?[jt]sx?": "eslint . --fix"
   },
   "volta": {
     "node": "24.13.0"

--- a/packages/data/data/ingredients/bitter/abbotts-bitters.json
+++ b/packages/data/data/ingredients/bitter/abbotts-bitters.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Abbott's Bitters",
+  "type": "bitter",
+  "categories": ["Aromatic Bitters"]
+}

--- a/packages/data/data/ingredients/bitter/sarsaparilla-bitters.json
+++ b/packages/data/data/ingredients/bitter/sarsaparilla-bitters.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Sarsaparilla bitters",
+  "type": "bitter"
+}

--- a/packages/data/data/ingredients/juice/tomato-water.json
+++ b/packages/data/data/ingredients/juice/tomato-water.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Tomato water",
+  "type": "juice"
+}

--- a/packages/data/data/ingredients/other/msg-solution.json
+++ b/packages/data/data/ingredients/other/msg-solution.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "MSG solution",
+  "type": "other"
+}

--- a/packages/data/data/ingredients/spirit/hampden-hlcf-classic.json
+++ b/packages/data/data/ingredients/spirit/hampden-hlcf-classic.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Hampden HLCF Classic",
+  "type": "spirit",
+  "categories": ["Navy Strength Jamaican Rum"]
+}

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/1906-martini.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/1906-martini.json
@@ -52,6 +52,10 @@
     {
       "type": "youtube",
       "videoId": "2ThWDvwgbWg"
+    },
+    {
+      "type": "youtube",
+      "videoId": "d3dVE7L4Gww"
     }
   ]
 }

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/barracuda.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/barracuda.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Barracuda",
+  "preparation": "shaken",
+  "served_on": "up",
+  "glassware": "coupe",
+  "ingredients": [
+    {
+      "name": "Simple syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lemon juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Sherry (Oloroso)",
+      "type": "category",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Aperol",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Garnish with a lemon twist."],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "4RvvsAU4ZdE"
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/heirloom-martini.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/heirloom-martini.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Heirloom Martini",
+  "preparation": "stirred",
+  "served_on": "up",
+  "glassware": "martini",
+  "ingredients": [
+    {
+      "name": "MSG solution",
+      "type": "other",
+      "quantity": {
+        "amount": 3,
+        "unit": "drop"
+      }
+    },
+    {
+      "name": "Tomato water",
+      "type": "juice",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Grapefruit juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Simple syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lime juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Aperol",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Gin",
+      "type": "category",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "d3dVE7L4Gww"
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/negroni-svegliato.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/negroni-svegliato.json
@@ -39,6 +39,10 @@
     {
       "type": "youtube",
       "videoId": "00x8KHz935c"
+    },
+    {
+      "type": "youtube",
+      "videoId": "d3dVE7L4Gww"
     }
   ]
 }

--- a/packages/data/data/recipes/youtube-channel/make-and-drink/adrift-rum-barrel.json
+++ b/packages/data/data/recipes/youtube-channel/make-and-drink/adrift-rum-barrel.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Adrift Rum Barrel",
+  "preparation": "shaken",
+  "served_on": "crushed ice",
+  "glassware": "tiki",
+  "ingredients": [
+    {
+      "name": "Sarsaparilla bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 4,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Abbott's Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Lime juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Orange juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Grapefruit juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Passion fruit syrup",
+      "type": "category",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Demerara syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Honey syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Allspice Dram",
+      "type": "category",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Hampden HLCF Classic",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Coruba",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Hamilton 151 Demerara rum",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Worthy Park Estate 109 Dark Rum",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Vince Polizzi"
+    },
+    {
+      "relation": "bar",
+      "source": "Adrift",
+      "location": "Denver, CO"
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "KQmE1lDgifU"
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/make-and-drink/banana-oleo-daiquiri.json
+++ b/packages/data/data/recipes/youtube-channel/make-and-drink/banana-oleo-daiquiri.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Banana Oleo Daiquiri",
+  "preparation": "shaken",
+  "served_on": "up",
+  "glassware": "coupe",
+  "ingredients": [
+    {
+      "name": "Banana oleosaccharum",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lime juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Two James Doctor Bird rum",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Planteray OFTD",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Timothy Dennihan"
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "c7zL6zlTdQs"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #246

## New recipes

- **Heirloom Martini** (Educated Barfly) — gin, tomato water, grapefruit juice, lime juice, Aperol, simple syrup, MSG solution
- **Barracuda** (Educated Barfly) — Oloroso sherry, Aperol, lemon juice, simple syrup
- **Adrift Rum Barrel** (Make and Drink) — recipe by Vince Polizzi from Adrift bar in Denver; quad-rum tiki build with sarsaparilla & Abbott's bitters
- **Banana Oleo Daiquiri** (Make and Drink) — recipe by Timothy Dennihan; Doctor Bird + OFTD with homemade banana oleosaccharum

## Updated refs

- **Negroni Svegliato** — added video `d3dVE7L4Gww`
- **1906 Martini** — added video `d3dVE7L4Gww`

## New ingredients

- `Hampden HLCF Classic` (spirit, Navy Strength Jamaican Rum)
- `Abbott's Bitters` (bitter, Aromatic Bitters)
- `Sarsaparilla bitters` (bitter)
- `MSG solution` (other)
- `Tomato water` (juice)

## Skipped

- Spike's Breezeway: "We Tried Ed Hamilton's Secret New Coffee Liqueur" — product review/tasting, no recipe in description

## Also fixed

`package.json` nano-staged config used `yarn oxfmt` / `yarn eslint`, which fails in Yarn 4 since these aren't defined scripts. Changed to `oxfmt` / `eslint` directly (local binaries are on PATH in the hook environment).