### PR TITLE
feat: add recipes from YouTube videos (week of 2026-05-04)

### DIFF
--- a/packages/data/data/ingredients/juice/clarified-pineapple-strawberry-juice.json
+++ b/packages/data/data/ingredients/juice/clarified-pineapple-strawberry-juice.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Clarified pineapple strawberry juice",
+  "type": "juice",
+  "ingredients": [
+    {
+      "name": "Pineapple juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 2,
+        "unit": "part"
+      }
+    },
+    {
+      "name": "Strawberry",
+      "type": "fruit",
+      "technique": {
+        "technique": "muddled"
+      },
+      "quantity": {
+        "amount": 1,
+        "unit": "part"
+      }
+    }
+  ],
+  "instructions": [
+    "Juice the strawberries (or extract juice from fresh fruit) and combine with pineapple juice to get total juice volume",
+    "Set aside 25% of the total juice; weigh it and add 0.2% agar agar (based on total juice weight)",
+    "Heat the agar mixture while whisking and bring to a boil",
+    "Whisk the boiled agar mixture back into the remaining 75% of juice",
+    "Refrigerate for ~1 hour until fully set",
+    "Break the gel and strain through cheesecloth, letting it fully filter",
+    "Yield is approximately 70% of the initial juice volume"
+  ]
+}

--- a/packages/data/data/ingredients/juice/tamarind-juice.json
+++ b/packages/data/data/ingredients/juice/tamarind-juice.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Tamarind juice",
+  "type": "juice"
+}

--- a/packages/data/data/ingredients/other/citric-acid.json
+++ b/packages/data/data/ingredients/other/citric-acid.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Citric acid",
+  "type": "other"
+}

--- a/packages/data/data/ingredients/other/malic-acid.json
+++ b/packages/data/data/ingredients/other/malic-acid.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Malic acid",
+  "type": "other"
+}

--- a/packages/data/data/ingredients/soda/sprite.json
+++ b/packages/data/data/ingredients/soda/sprite.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Sprite",
+  "type": "soda"
+}

--- a/packages/data/data/ingredients/spirit/volcan-de-mi-tierra-reposado.json
+++ b/packages/data/data/ingredients/spirit/volcan-de-mi-tierra-reposado.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Volcán de mi Tierra Reposado",
+  "type": "spirit",
+  "categories": ["Tequila Reposado"]
+}

--- a/packages/data/data/ingredients/syrup/masala-syrup.json
+++ b/packages/data/data/ingredients/syrup/masala-syrup.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Masala syrup",
+  "type": "syrup",
+  "ingredients": [
+    {
+      "name": "sugar",
+      "type": "other",
+      "quantity": {
+        "amount": 250,
+        "unit": "gram"
+      }
+    },
+    {
+      "name": "Water",
+      "type": "other",
+      "quantity": {
+        "amount": 250,
+        "unit": "gram"
+      }
+    },
+    {
+      "name": "Ginger",
+      "type": "spice",
+      "quantity": {
+        "amount": 85,
+        "unit": "gram"
+      }
+    },
+    {
+      "name": "Cinnamon",
+      "type": "spice",
+      "quantity": {
+        "amount": 20,
+        "unit": "gram"
+      }
+    },
+    {
+      "name": "cardamom pods",
+      "type": "spice",
+      "quantity": {
+        "amount": 3,
+        "unit": "gram"
+      }
+    },
+    {
+      "name": "Cloves",
+      "type": "spice",
+      "quantity": {
+        "amount": 2,
+        "unit": "gram"
+      }
+    }
+  ],
+  "instructions": [
+    "Combine all ingredients in a sous-vide bag",
+    "Cook at 70°C (158°F) for 2 hours, mixing twice during the process",
+    "Chill in an ice bath",
+    "Fine strain when bottling"
+  ]
+}

--- a/packages/data/data/ingredients/syrup/tropical-berry-cordial.json
+++ b/packages/data/data/ingredients/syrup/tropical-berry-cordial.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Tropical berry cordial",
+  "type": "syrup",
+  "ingredients": [
+    {
+      "name": "Clarified pineapple strawberry juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 500,
+        "unit": "ml"
+      }
+    },
+    {
+      "name": "Agave syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 52,
+        "unit": "gram"
+      }
+    },
+    {
+      "name": "Citric acid",
+      "type": "other",
+      "quantity": {
+        "amount": 3,
+        "unit": "gram"
+      }
+    },
+    {
+      "name": "Malic acid",
+      "type": "other",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "gram"
+      }
+    },
+    {
+      "name": "Salt",
+      "type": "other",
+      "quantity": {
+        "amount": 0.6,
+        "unit": "gram"
+      }
+    }
+  ],
+  "instructions": ["Mix all ingredients to combine"]
+}

--- a/packages/data/data/ingredients/syrup/tropical-berry-cordial.json
+++ b/packages/data/data/ingredients/syrup/tropical-berry-cordial.json
@@ -44,5 +44,11 @@
       }
     }
   ],
-  "instructions": ["Mix all ingredients to combine"]
+  "instructions": ["Mix all ingredients to combine"],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "37FkxmGDeGQ"
+    }
+  ]
 }

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/9th-wonder.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/9th-wonder.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "9th Wonder",
+  "preparation": "shaken",
+  "served_on": "up",
+  "glassware": "coupe",
+  "ingredients": [
+    {
+      "name": "Lime juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Ancho Reyes Ancho Chile Liqueur",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Crème de Cacao",
+      "type": "category",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Tequila (Blanco)",
+      "type": "category",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Add all ingredients to a shaker with ice",
+    "Shake until well chilled",
+    "Strain into a chilled coupe",
+    "Garnish with a lemon wheel"
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "mui53iIiIVE",
+      "start": 90
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/bebbo-con-hongos.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/bebbo-con-hongos.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Bebbo Con Hongos",
+  "preparation": "shaken",
+  "served_on": "up",
+  "glassware": "coupe",
+  "ingredients": [
+    {
+      "name": "blood orange juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lemon juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Honey syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Charanda",
+      "type": "category",
+      "technique": {
+        "technique": "infusion",
+        "agent": "dried mushrooms"
+      },
+      "quantity": {
+        "amount": 2,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Add all ingredients to a shaker with ice",
+    "Shake until well chilled",
+    "Strain into a chilled coupe",
+    "Garnish with a lemon wheel"
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "mui53iIiIVE",
+      "start": 597
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/bicicletta.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/bicicletta.json
@@ -27,6 +27,10 @@
     {
       "type": "youtube",
       "videoId": "WYceYlQ2Yj0"
+    },
+    {
+      "type": "youtube",
+      "videoId": "xVUgObC4jZk"
     }
   ]
 }

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/cal-rey-margarita.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/cal-rey-margarita.json
@@ -64,6 +64,10 @@
     {
       "type": "youtube",
       "videoId": "LqZFLcmUFow"
+    },
+    {
+      "type": "youtube",
+      "videoId": "xz2_IWcVVVE"
     }
   ]
 }

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/snake-eyes.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/snake-eyes.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Snake Eyes",
+  "preparation": "shaken",
+  "served_on": "up",
+  "glassware": "coupe",
+  "ingredients": [
+    {
+      "name": "Lime juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Cane syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Coconut water",
+      "type": "other",
+      "quantity": {
+        "amount": 2,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Banana liqueur",
+      "type": "category",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Mezcal",
+      "type": "category",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Add all ingredients to a shaker with ice",
+    "Shake until well chilled",
+    "Strain into a chilled coupe",
+    "Garnish with a salt rim"
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "mui53iIiIVE",
+      "start": 311
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/jason-miller/oaxacan-dead.json
+++ b/packages/data/data/recipes/youtube-channel/jason-miller/oaxacan-dead.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Oaxacan Dead",
+  "preparation": "shaken",
+  "served_on": "crushed ice",
+  "glassware": "tiki",
+  "ingredients": [
+    {
+      "name": "Grenadine",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Cinnamon syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Grapefruit juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lime juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Mezcal",
+      "type": "category",
+      "quantity": {
+        "amount": 1,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Falernum liqueur",
+      "type": "category",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Tequila Reposado",
+      "type": "category",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Blended Aged Rum (Jamaica)",
+      "type": "category",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Add all ingredients to a shaker with ice",
+    "Shake until well-chilled",
+    "Pour into a tiki glass filled with crushed ice"
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "JQ-cN_Uk95g"
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/jason-miller/yub-nub.json
+++ b/packages/data/data/recipes/youtube-channel/jason-miller/yub-nub.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Yub Nub",
+  "preparation": "shaken",
+  "served_on": "crushed ice",
+  "glassware": "tiki",
+  "ingredients": [
+    {
+      "name": "Passion fruit syrup",
+      "type": "category",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lime juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Pineapple juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Orange juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Spiced Rum",
+      "type": "category",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Pineapple Rum",
+      "type": "category",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Add all ingredients to a shaker with ice",
+    "Shake until well-chilled",
+    "Pour into a tiki glass filled with crushed ice"
+  ],
+  "attributions": [
+    {
+      "relation": "bar",
+      "source": "Oga's Cantina",
+      "location": "Disneyland"
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "LVh3ZOMGI4U"
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/make-and-drink/hawaiian-scorpion.json
+++ b/packages/data/data/recipes/youtube-channel/make-and-drink/hawaiian-scorpion.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Hawaiian Scorpion",
+  "preparation": "shaken",
+  "served_on": "crushed ice",
+  "glassware": "punch",
+  "servings": 5,
+  "ingredients": [
+    {
+      "name": "Demerara sugar",
+      "type": "other",
+      "quantity": {
+        "amount": 2,
+        "unit": "tbsp"
+      }
+    },
+    {
+      "name": "Lemon juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 3.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Orange juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 5.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Okolehao",
+      "type": "spirit",
+      "quantity": {
+        "amount": 10,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Combine all ingredients with ice and shake or stir to dissolve sugar",
+    "Strain into glasses over crushed ice",
+    "Garnish with mint and an orange slice"
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "EXpopwRVk5Y",
+      "start": 342
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/make-and-drink/meteor-strike.json
+++ b/packages/data/data/recipes/youtube-channel/make-and-drink/meteor-strike.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Meteor Strike",
+  "preparation": "shaken",
+  "served_on": "ice cubes",
+  "glassware": "highball",
+  "ingredients": [
+    {
+      "name": "Lime juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Pineapple juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Blue Curaçao",
+      "type": "category",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Triple Sec",
+      "type": "category",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Blended Lightly-aged Rum",
+      "type": "category",
+      "quantity": {
+        "amount": 2,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Sprite",
+      "type": "soda",
+      "technique": {
+        "technique": "application",
+        "method": "top"
+      },
+      "quantity": {
+        "amount": 2.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Shake all ingredients except Sprite with ice",
+    "Strain into a highball glass over fresh ice",
+    "Top with Sprite",
+    "Garnish with edible gold glitter"
+  ],
+  "attributions": [
+    {
+      "relation": "bar",
+      "source": "Bar Zenith",
+      "location": "Universal Epic Universe, Orlando, FL"
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "KDFvH2qmgOQ"
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/spike-breezeway-cocktail-hour/the-monkey-pod.json
+++ b/packages/data/data/recipes/youtube-channel/spike-breezeway-cocktail-hour/the-monkey-pod.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "The Monkey Pod",
+  "preparation": "shaken",
+  "served_on": "crushed ice",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Lime juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Coconut cream",
+      "type": "other",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Tamarind juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 2.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Black Blended Rum (Jamaica)",
+      "type": "category",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Column still lightly aged rum",
+      "type": "category",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Add ingredients to a double old fashioned glass with pebble ice",
+    "Shake until cold and combined",
+    "Pour back into the double old fashioned glass",
+    "Garnish with fresh mint"
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Derek \"Monkeyman\" Weaver"
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "PA91pkukbV4"
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/truffles-on-the-rocks/chaiwallahs-medicine.json
+++ b/packages/data/data/recipes/youtube-channel/truffles-on-the-rocks/chaiwallahs-medicine.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Chaiwallah's Medicine",
+  "preparation": "shaken",
+  "served_on": "ice cubes",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Masala syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lemon juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Whisky (Blended Scotch)",
+      "type": "category",
+      "technique": {
+        "technique": "infusion",
+        "agent": "English breakfast tea",
+        "agent_quantity": {
+          "amount": 7,
+          "unit": "gram"
+        },
+        "spirit_quantity": {
+          "amount": 200,
+          "unit": "ml"
+        },
+        "duration": "30 minutes"
+      },
+      "quantity": {
+        "amount": 2,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Whisky (Islay Scotch)",
+      "type": "category",
+      "technique": {
+        "technique": "application",
+        "method": "float"
+      },
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Shake all ingredients except the peated Scotch with ice until cold",
+    "Fine strain over fresh ice in an old fashioned glass",
+    "Float the peated Scotch on top",
+    "Garnish with 3 candied ginger pieces"
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "s5Zb1eh-C4Q"
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/truffles-on-the-rocks/tropical-berry-highball.json
+++ b/packages/data/data/recipes/youtube-channel/truffles-on-the-rocks/tropical-berry-highball.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Tropical Berry Highball",
+  "preparation": "other",
+  "served_on": "ice cubes",
+  "glassware": "highball",
+  "ingredients": [
+    {
+      "name": "Tropical berry cordial",
+      "type": "syrup",
+      "quantity": {
+        "amount": 150,
+        "unit": "ml"
+      }
+    },
+    {
+      "name": "Ancho Reyes Verde Chile Poblano Liqueur",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 5,
+        "unit": "ml"
+      }
+    },
+    {
+      "name": "Volcán de mi Tierra Reposado",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Combine all ingredients in a CO2 cream whipper",
+    "Charge with CO2, shake 10 seconds, then release the gas",
+    "Charge again, shake, and rest in the fridge",
+    "Prepare a highball glass with a light dusting of smoked paprika",
+    "Fill with ice, release gas from the siphon, and pour"
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "37FkxmGDeGQ"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds recipes from new YouTube videos listed in #255.

### New recipes

- **Educated Barfly**: 9th Wonder, Snake Eyes, Bebbo Con Hongos
- **Jason Miller**: Oaxacan Dead, Yub Nub
- **Make and Drink**: Hawaiian Scorpion, Meteor Strike
- **Spike's Breezeway**: The Monkey Pod
- **Truffles on the Rocks**: Chaiwallah's Medicine, Tropical Berry Highball

### Existing recipes (added video refs)

- Bicicletta (Educated Barfly)
- Cal Rey Margarita (Educated Barfly)

### Skipped (non-recipe content)

- *The Ultimate Backyard Escape* — bar tour vlog with no cocktail recipe
- *Easily Make Popsicles at Home...* — popsicle recipes, not cocktails

### New ingredients

- `Sprite` (soda)
- `Tamarind juice` (juice)
- `Clarified pineapple strawberry juice` (juice, with prep instructions)
- `Citric acid`, `Malic acid` (other)
- `Volcán de mi Tierra Reposado` (spirit)
- `Masala syrup`, `Tropical berry cordial` (syrup, with sub-ingredients)

Closes #255

## Test plan

- [x] `yarn check-data` passes
- [x] `yarn lint` passes
- [x] `yarn vitest --run` passes (330 tests)