### PR TITLE
feat: add recently added recipes list

### DIFF
--- a/apps/web/app/list/recently-added/page.tsx
+++ b/apps/web/app/list/recently-added/page.tsx
@@ -1,0 +1,33 @@
+import { getRecentlyAddedRecipes } from '@cocktails/data/recipes';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import { List, ListItem, ListItemText, Paper } from '@mui/material';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { Suspense } from 'react';
+import AppHeader from '#/components/AppHeader';
+import { getRecipeUrl } from '#/modules/url';
+
+export const metadata: Metadata = {
+  title: 'Cocktail Index | Recently Added',
+};
+
+export default async function RecentlyAddedPage() {
+  const recipes = await getRecentlyAddedRecipes();
+
+  return (
+    <Suspense>
+      <AppHeader title="Recently Added" />
+      <List sx={{ mt: 2 }}>
+        <Paper square>
+          {recipes.map((recipe) => (
+            <Link href={getRecipeUrl(recipe)} key={getRecipeUrl(recipe)}>
+              <ListItem divider secondaryAction={<ChevronRightIcon />}>
+                <ListItemText primary={recipe.name} secondary={recipe.source.name} />
+              </ListItem>
+            </Link>
+          ))}
+        </Paper>
+      </List>
+    </Suspense>
+  );
+}

--- a/apps/web/app/list/recently-added/page.tsx
+++ b/apps/web/app/list/recently-added/page.tsx
@@ -1,4 +1,4 @@
-import { getRecentlyUpdatedRecipes } from '@cocktails/data/recipes';
+import { getRecentlyAddedRecipes } from '@cocktails/data/recipes';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { List, ListItem, ListItemText, Paper } from '@mui/material';
 import type { Metadata } from 'next';
@@ -8,15 +8,15 @@ import AppHeader from '#/components/AppHeader';
 import { getRecipeUrl } from '#/modules/url';
 
 export const metadata: Metadata = {
-  title: 'Cocktail Index | Recently Updated',
+  title: 'Cocktail Index | Recently Added',
 };
 
-export default async function RecentlyUpdatedPage() {
-  const recipes = await getRecentlyUpdatedRecipes();
+export default async function RecentlyAddedPage() {
+  const recipes = await getRecentlyAddedRecipes();
 
   return (
     <Suspense>
-      <AppHeader title="Recently Updated" />
+      <AppHeader title="Recently Added" />
       <List sx={{ mt: 2 }}>
         <Paper square>
           {recipes.map((recipe) => (

--- a/apps/web/app/list/recently-updated/page.tsx
+++ b/apps/web/app/list/recently-updated/page.tsx
@@ -1,4 +1,4 @@
-import { getRecentlyAddedRecipes } from '@cocktails/data/recipes';
+import { getRecentlyUpdatedRecipes } from '@cocktails/data/recipes';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { List, ListItem, ListItemText, Paper } from '@mui/material';
 import type { Metadata } from 'next';
@@ -8,15 +8,15 @@ import AppHeader from '#/components/AppHeader';
 import { getRecipeUrl } from '#/modules/url';
 
 export const metadata: Metadata = {
-  title: 'Cocktail Index | Recently Added',
+  title: 'Cocktail Index | Recently Updated',
 };
 
-export default async function RecentlyAddedPage() {
-  const recipes = await getRecentlyAddedRecipes();
+export default async function RecentlyUpdatedPage() {
+  const recipes = await getRecentlyUpdatedRecipes();
 
   return (
     <Suspense>
-      <AppHeader title="Recently Added" />
+      <AppHeader title="Recently Updated" />
       <List sx={{ mt: 2 }}>
         <Paper square>
           {recipes.map((recipe) => (

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -3,6 +3,7 @@ import { getAllSources } from '@cocktails/data/sources';
 import BookIcon from '@mui/icons-material/Book';
 import CalculatorIcon from '@mui/icons-material/Calculate';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import HistoryIcon from '@mui/icons-material/History';
 import PodcastIcon from '@mui/icons-material/Podcasts';
 import SearchIcon from '@mui/icons-material/Search';
 import YoutubeIcon from '@mui/icons-material/YouTube';
@@ -26,7 +27,7 @@ import {
   getBarListUrl,
   getBottleListUrl,
   getIngredientListUrl,
-  getRecentlyAddedUrl,
+  getRecentlyUpdatedUrl,
   getRecipeListUrl,
   getSourceUrl,
 } from '#/modules/url';
@@ -76,6 +77,16 @@ export default async function HomePage() {
                   <SearchIcon />
                 </ListItemIcon>
                 <ListItemText primary="All Recipes" />
+              </ListItemButton>
+            </ListItem>
+          </Link>
+          <Link href={getRecentlyUpdatedUrl()}>
+            <ListItem disablePadding divider secondaryAction={<ChevronRightIcon />}>
+              <ListItemButton>
+                <ListItemIcon>
+                  <HistoryIcon />
+                </ListItemIcon>
+                <ListItemText primary="Recently Updated" />
               </ListItemButton>
             </ListItem>
           </Link>
@@ -156,11 +167,6 @@ export default async function HomePage() {
           <ul>
             <ListSubheader>Other lists</ListSubheader>
             <Paper square>
-              <Link href={getRecentlyAddedUrl()}>
-                <ListItem divider secondaryAction={<ChevronRightIcon />}>
-                  <ListItemText primary="Recently Added" />
-                </ListItem>
-              </Link>
               <Link href={getAuthorListUrl()}>
                 <ListItem divider secondaryAction={<ChevronRightIcon />}>
                   <ListItemText primary="By Authors" />

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -27,7 +27,7 @@ import {
   getBarListUrl,
   getBottleListUrl,
   getIngredientListUrl,
-  getRecentlyUpdatedUrl,
+  getRecentlyAddedUrl,
   getRecipeListUrl,
   getSourceUrl,
 } from '#/modules/url';
@@ -80,13 +80,13 @@ export default async function HomePage() {
               </ListItemButton>
             </ListItem>
           </Link>
-          <Link href={getRecentlyUpdatedUrl()}>
+          <Link href={getRecentlyAddedUrl()}>
             <ListItem disablePadding divider secondaryAction={<ChevronRightIcon />}>
               <ListItemButton>
                 <ListItemIcon>
                   <HistoryIcon />
                 </ListItemIcon>
-                <ListItemText primary="Recently Updated" />
+                <ListItemText primary="Recently Added" />
               </ListItemButton>
             </ListItem>
           </Link>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -26,6 +26,7 @@ import {
   getBarListUrl,
   getBottleListUrl,
   getIngredientListUrl,
+  getRecentlyAddedUrl,
   getRecipeListUrl,
   getSourceUrl,
 } from '#/modules/url';
@@ -155,6 +156,11 @@ export default async function HomePage() {
           <ul>
             <ListSubheader>Other lists</ListSubheader>
             <Paper square>
+              <Link href={getRecentlyAddedUrl()}>
+                <ListItem divider secondaryAction={<ChevronRightIcon />}>
+                  <ListItemText primary="Recently Added" />
+                </ListItem>
+              </Link>
               <Link href={getAuthorListUrl()}>
                 <ListItem divider secondaryAction={<ChevronRightIcon />}>
                   <ListItemText primary="By Authors" />

--- a/apps/web/modules/url.ts
+++ b/apps/web/modules/url.ts
@@ -23,8 +23,8 @@ export function getRecipeListUrl() {
   return '/list/recipes';
 }
 
-export function getRecentlyUpdatedUrl() {
-  return '/list/recently-updated';
+export function getRecentlyAddedUrl() {
+  return '/list/recently-added';
 }
 
 export function getBottleListUrl() {

--- a/apps/web/modules/url.ts
+++ b/apps/web/modules/url.ts
@@ -23,8 +23,8 @@ export function getRecipeListUrl() {
   return '/list/recipes';
 }
 
-export function getRecentlyAddedUrl() {
-  return '/list/recently-added';
+export function getRecentlyUpdatedUrl() {
+  return '/list/recently-updated';
 }
 
 export function getBottleListUrl() {

--- a/apps/web/modules/url.ts
+++ b/apps/web/modules/url.ts
@@ -23,6 +23,10 @@ export function getRecipeListUrl() {
   return '/list/recipes';
 }
 
+export function getRecentlyAddedUrl() {
+  return '/list/recently-added';
+}
+
 export function getBottleListUrl() {
   return '/list/bottles';
 }

--- a/packages/data/src/modules/recipes.ts
+++ b/packages/data/src/modules/recipes.ts
@@ -1,5 +1,9 @@
+import { execFile as execFileCb } from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { promisify } from 'node:util';
+
+const execFile = promisify(execFileCb);
 import slugify from '@sindresorhus/slugify';
 import { uniqBy } from 'lodash';
 import memo from 'lodash/memoize';
@@ -173,64 +177,90 @@ export const getRecipesFromSource = memo(
 );
 
 export const getRecentlyUpdatedRecipes = memo(async (): Promise<Recipe[]> => {
-  const sourceTypes = await fs.readdir(RECIPE_ROOT);
+  const { stdout: repoRootRaw } = await execFile(
+    'git',
+    ['rev-parse', '--show-toplevel'],
+    {
+      cwd: RECIPE_ROOT,
+    },
+  );
+  const repoRoot = repoRootRaw.trim();
+  const recipeRelPath = path.relative(repoRoot, RECIPE_ROOT);
 
-  const sourceDirs = await Promise.all(
-    sourceTypes.map(async (sourceType) => {
-      const sourceSlugs = await fs.readdir(path.join(RECIPE_ROOT, sourceType));
-      return sourceSlugs.map((sourceSlug) => ({ sourceType, sourceSlug }));
-    }),
+  // --diff-filter=A: only commits that first introduced each file (immune to bulk edits)
+  // git log is newest-first, so the first occurrence of each path is its most recent add
+  const { stdout: gitLog } = await execFile(
+    'git',
+    [
+      '-c',
+      'core.quotePath=false',
+      'log',
+      '--diff-filter=A',
+      '--name-only',
+      '--format=COMMIT %ai',
+      '--',
+      recipeRelPath,
+    ],
+    { cwd: repoRoot },
   );
 
-  const recipeFiles = await Promise.all(
-    sourceDirs.flat().map(async ({ sourceType, sourceSlug }) => {
-      const sourcePath = path.join(RECIPE_ROOT, sourceType, sourceSlug);
-      const entries = await fs.readdir(sourcePath);
-      const results: {
-        sourceType: Source['type'];
-        sourceSlug: string;
-        recipeSlug: string;
-        chapter?: string;
-        mtime: Date;
-      }[] = [];
+  const seen = new Set<string>();
+  const recent: Array<{
+    sourceType: Source['type'];
+    sourceSlug: string;
+    recipeSlug: string;
+    chapter?: string;
+  }> = [];
 
-      for (const entry of entries) {
-        if (entry === '_source.json') continue;
+  let currentDate: Date | null = null;
 
-        const entryPath = path.join(sourcePath, entry);
-        const stat = await fs.stat(entryPath);
+  for (const raw of gitLog.split('\n')) {
+    if (recent.length >= 30) break;
+    const line = raw.trim();
+    if (!line) continue;
 
-        if (stat.isDirectory() && isChapterFolder(entry)) {
-          const chapterFiles = await fs.readdir(entryPath);
-          for (const recipeFilename of chapterFiles) {
-            if (!recipeFilename.endsWith('.json')) continue;
-            const recipeStat = await fs.stat(path.join(entryPath, recipeFilename));
-            results.push({
-              sourceType: sourceType as Source['type'],
-              sourceSlug,
-              recipeSlug: path.basename(recipeFilename, '.json'),
-              chapter: entry,
-              mtime: recipeStat.mtime,
-            });
-          }
-        } else if (entry.endsWith('.json')) {
-          results.push({
+    if (line.startsWith('COMMIT ')) {
+      currentDate = new Date(line.slice(7));
+    } else if (currentDate && line.endsWith('.json') && !line.includes('_source.json')) {
+      const relToRecipes = path.relative(recipeRelPath, line);
+      const parts = relToRecipes.split('/');
+
+      let entry: (typeof recent)[number] | null = null;
+
+      const sourceType = parts[0];
+      const sourceSlug = parts[1];
+
+      if (parts.length === 3) {
+        const filename = parts[2];
+        if (sourceType && sourceSlug && filename) {
+          entry = {
             sourceType: sourceType as Source['type'],
             sourceSlug,
-            recipeSlug: path.basename(entry, '.json'),
-            mtime: stat.mtime,
-          });
+            recipeSlug: path.basename(filename, '.json'),
+          };
+        }
+      } else if (parts.length === 4) {
+        const chapter = parts[2];
+        const filename = parts[3];
+        if (sourceType && sourceSlug && chapter && filename) {
+          entry = {
+            sourceType: sourceType as Source['type'],
+            sourceSlug,
+            recipeSlug: path.basename(filename, '.json'),
+            chapter,
+          };
         }
       }
 
-      return results;
-    }),
-  );
-
-  const recent = recipeFiles
-    .flat()
-    .toSorted((a, b) => b.mtime.getTime() - a.mtime.getTime())
-    .slice(0, 30);
+      if (entry) {
+        const key = `${entry.sourceType}/${entry.sourceSlug}/${entry.chapter ?? ''}/${entry.recipeSlug}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          recent.push(entry);
+        }
+      }
+    }
+  }
 
   return Promise.all(
     recent.map(({ sourceType, sourceSlug, recipeSlug, chapter }) =>

--- a/packages/data/src/modules/recipes.ts
+++ b/packages/data/src/modules/recipes.ts
@@ -172,6 +172,73 @@ export const getRecipesFromSource = memo(
   },
 );
 
+export const getRecentlyAddedRecipes = memo(async (): Promise<Recipe[]> => {
+  const sourceTypes = await fs.readdir(RECIPE_ROOT);
+
+  const sourceDirs = await Promise.all(
+    sourceTypes.map(async (sourceType) => {
+      const sourceSlugs = await fs.readdir(path.join(RECIPE_ROOT, sourceType));
+      return sourceSlugs.map((sourceSlug) => ({ sourceType, sourceSlug }));
+    }),
+  );
+
+  const recipeFiles = await Promise.all(
+    sourceDirs.flat().map(async ({ sourceType, sourceSlug }) => {
+      const sourcePath = path.join(RECIPE_ROOT, sourceType, sourceSlug);
+      const entries = await fs.readdir(sourcePath);
+      const results: {
+        sourceType: Source['type'];
+        sourceSlug: string;
+        recipeSlug: string;
+        chapter?: string;
+        mtime: Date;
+      }[] = [];
+
+      for (const entry of entries) {
+        if (entry === '_source.json') continue;
+
+        const entryPath = path.join(sourcePath, entry);
+        const stat = await fs.stat(entryPath);
+
+        if (stat.isDirectory() && isChapterFolder(entry)) {
+          const chapterFiles = await fs.readdir(entryPath);
+          for (const recipeFilename of chapterFiles) {
+            if (!recipeFilename.endsWith('.json')) continue;
+            const recipeStat = await fs.stat(path.join(entryPath, recipeFilename));
+            results.push({
+              sourceType: sourceType as Source['type'],
+              sourceSlug,
+              recipeSlug: path.basename(recipeFilename, '.json'),
+              chapter: entry,
+              mtime: recipeStat.mtime,
+            });
+          }
+        } else if (entry.endsWith('.json')) {
+          results.push({
+            sourceType: sourceType as Source['type'],
+            sourceSlug,
+            recipeSlug: path.basename(entry, '.json'),
+            mtime: stat.mtime,
+          });
+        }
+      }
+
+      return results;
+    }),
+  );
+
+  const recent = recipeFiles
+    .flat()
+    .toSorted((a, b) => b.mtime.getTime() - a.mtime.getTime())
+    .slice(0, 30);
+
+  return Promise.all(
+    recent.map(({ sourceType, sourceSlug, recipeSlug, chapter }) =>
+      getRecipe({ type: sourceType, slug: sourceSlug }, recipeSlug, chapter),
+    ),
+  );
+});
+
 export const getRecipeByCategory = memo(
   async (category: Category): Promise<Recipe[]> => {
     const recipes = await getAllRecipes();

--- a/packages/data/src/modules/recipes.ts
+++ b/packages/data/src/modules/recipes.ts
@@ -176,7 +176,7 @@ export const getRecipesFromSource = memo(
   },
 );
 
-export const getRecentlyUpdatedRecipes = memo(async (): Promise<Recipe[]> => {
+export const getRecentlyAddedRecipes = memo(async (): Promise<Recipe[]> => {
   const { stdout: repoRootRaw } = await execFile(
     'git',
     ['rev-parse', '--show-toplevel'],

--- a/packages/data/src/modules/recipes.ts
+++ b/packages/data/src/modules/recipes.ts
@@ -172,7 +172,7 @@ export const getRecipesFromSource = memo(
   },
 );
 
-export const getRecentlyAddedRecipes = memo(async (): Promise<Recipe[]> => {
+export const getRecentlyUpdatedRecipes = memo(async (): Promise<Recipe[]> => {
   const sourceTypes = await fs.readdir(RECIPE_ROOT);
 
   const sourceDirs = await Promise.all(


### PR DESCRIPTION
## Summary

- Adds `getRecentlyAddedRecipes()` to `@cocktails/data/recipes` — traverses the filesystem, captures `mtime` per recipe file, sorts newest-first, and returns the top 30
- Adds `/list/recently-added` page showing those 30 recipes with their source name as secondary text
- Links the new page from the homepage's "Other lists" section

## Test plan

- [ ] Homepage shows "Recently Added" in the "Other lists" section
- [ ] Clicking it navigates to `/list/recently-added`
- [ ] Page renders 30 recipes ordered by most-recently-modified file first
- [ ] Each recipe shows its source name (book / channel) as subtitle
- [ ] `yarn lint` and `yarn vitest --run` pass