### PR TITLE
feat: detect similar author/bar names in check-data

### DIFF
--- a/packages/data/data/recipes/book/death-co-welcome-home/02_Light & Playful (Daiquiri)/awkwardly-tongue-tied.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/02_Light & Playful (Daiquiri)/awkwardly-tongue-tied.json
@@ -58,7 +58,7 @@
   "attributions": [
     {
       "relation": "recipe author",
-      "source": "Jared Weigand"
+      "source": "Jarred Weigand"
     },
     {
       "relation": "bar",

--- a/packages/data/data/recipes/book/death-co-welcome-home/02_Light & Playful (Daiquiri)/inspector-norse.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/02_Light & Playful (Daiquiri)/inspector-norse.json
@@ -74,7 +74,7 @@
   "attributions": [
     {
       "relation": "recipe author",
-      "source": "Jared Weigand"
+      "source": "Jarred Weigand"
     },
     {
       "relation": "bar",

--- a/packages/data/data/recipes/book/death-co-welcome-home/02_Light & Playful (Daiquiri)/rumor-mill.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/02_Light & Playful (Daiquiri)/rumor-mill.json
@@ -65,7 +65,7 @@
   "attributions": [
     {
       "relation": "recipe author",
-      "source": "Jared Weigand"
+      "source": "Jarred Weigand"
     },
     {
       "relation": "bar",

--- a/packages/data/data/recipes/book/death-co-welcome-home/02_Light & Playful (Daiquiri)/strange-encounters.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/02_Light & Playful (Daiquiri)/strange-encounters.json
@@ -73,7 +73,7 @@
   "attributions": [
     {
       "relation": "recipe author",
-      "source": "Jared Weigand"
+      "source": "Jarred Weigand"
     },
     {
       "relation": "bar",

--- a/packages/data/data/recipes/book/death-co-welcome-home/03_Bright & Confident (Sidecar)/full-sail.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/03_Bright & Confident (Sidecar)/full-sail.json
@@ -69,7 +69,7 @@
   "attributions": [
     {
       "relation": "recipe author",
-      "source": "Jared Weigand"
+      "source": "Jarred Weigand"
     },
     {
       "relation": "bar",

--- a/packages/data/data/recipes/book/death-co-welcome-home/03_Bright & Confident (Sidecar)/glory-days.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/03_Bright & Confident (Sidecar)/glory-days.json
@@ -69,7 +69,7 @@
   "attributions": [
     {
       "relation": "recipe author",
-      "source": "Jared Weigand"
+      "source": "Jarred Weigand"
     },
     {
       "relation": "bar",

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/noble-one.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/noble-one.json
@@ -50,7 +50,7 @@
   "attributions": [
     {
       "relation": "recipe author",
-      "source": "Javel Taft"
+      "source": "Javelle Taft"
     },
     {
       "relation": "bar",

--- a/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/vantage-point.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/04_Boozy & Honest (Old-Fashioned)/vantage-point.json
@@ -33,7 +33,7 @@
   "attributions": [
     {
       "relation": "recipe author",
-      "source": "Javel Taft"
+      "source": "Javelle Taft"
     },
     {
       "relation": "bar",

--- a/packages/data/data/recipes/book/death-co-welcome-home/05_Elegant & Graceful (Martini)/between-the-lines.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/05_Elegant & Graceful (Martini)/between-the-lines.json
@@ -44,7 +44,7 @@
   "attributions": [
     {
       "relation": "recipe author",
-      "source": "Jared Weigand"
+      "source": "Jarred Weigand"
     },
     {
       "relation": "bar",

--- a/packages/data/data/recipes/book/death-co-welcome-home/05_Rich & Comforting (Flip)/sabrosa.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/05_Rich & Comforting (Flip)/sabrosa.json
@@ -62,7 +62,7 @@
   "attributions": [
     {
       "relation": "recipe author",
-      "source": "Jared Weigand"
+      "source": "Jarred Weigand"
     },
     {
       "relation": "bar",

--- a/packages/data/data/recipes/book/death-co-welcome-home/05_Rich & Comforting (Flip)/space-cowboy.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/05_Rich & Comforting (Flip)/space-cowboy.json
@@ -65,7 +65,7 @@
   "attributions": [
     {
       "relation": "recipe author",
-      "source": "Jared Weigand"
+      "source": "Jarred Weigand"
     },
     {
       "relation": "bar",

--- a/packages/data/data/recipes/book/easy-tiki/02_Modern Recipes/good-enough-gatsby.json
+++ b/packages/data/data/recipes/book/easy-tiki/02_Modern Recipes/good-enough-gatsby.json
@@ -67,7 +67,7 @@
     },
     {
       "relation": "bar",
-      "source": "Death & Co.",
+      "source": "Death & Co",
       "location": "Denver, CO"
     }
   ],

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/heirloom-martini.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/heirloom-martini.json
@@ -14,14 +14,6 @@
       }
     },
     {
-      "name": "Tomato water",
-      "type": "juice",
-      "quantity": {
-        "amount": 1.5,
-        "unit": "oz"
-      }
-    },
-    {
       "name": "Grapefruit juice",
       "type": "juice",
       "quantity": {
@@ -42,6 +34,14 @@
       "type": "juice",
       "quantity": {
         "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Tomato water",
+      "type": "juice",
+      "quantity": {
+        "amount": 1.5,
         "unit": "oz"
       }
     },

--- a/packages/data/data/recipes/youtube-channel/make-and-drink/adrift-rum-barrel.json
+++ b/packages/data/data/recipes/youtube-channel/make-and-drink/adrift-rum-barrel.json
@@ -6,6 +6,14 @@
   "glassware": "tiki",
   "ingredients": [
     {
+      "name": "Abbott's Bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
       "name": "Sarsaparilla bitters",
       "type": "bitter",
       "quantity": {
@@ -14,11 +22,11 @@
       }
     },
     {
-      "name": "Abbott's Bitters",
-      "type": "bitter",
+      "name": "Passion fruit syrup",
+      "type": "category",
       "quantity": {
-        "amount": 1,
-        "unit": "dash"
+        "amount": 0.25,
+        "unit": "oz"
       }
     },
     {
@@ -38,22 +46,6 @@
       }
     },
     {
-      "name": "Grapefruit juice",
-      "type": "juice",
-      "quantity": {
-        "amount": 0.75,
-        "unit": "oz"
-      }
-    },
-    {
-      "name": "Passion fruit syrup",
-      "type": "category",
-      "quantity": {
-        "amount": 0.25,
-        "unit": "oz"
-      }
-    },
-    {
       "name": "Demerara syrup",
       "type": "syrup",
       "quantity": {
@@ -66,6 +58,14 @@
       "type": "syrup",
       "quantity": {
         "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Grapefruit juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.75,
         "unit": "oz"
       }
     },

--- a/packages/data/data/recipes/youtube-channel/make-and-drink/almond-brother.json
+++ b/packages/data/data/recipes/youtube-channel/make-and-drink/almond-brother.json
@@ -66,7 +66,7 @@
     },
     {
       "relation": "bar",
-      "source": "Death & Co.",
+      "source": "Death & Co",
       "location": "New York, NY"
     }
   ],

--- a/packages/data/data/recipes/youtube-channel/make-and-drink/banana-oleo-daiquiri.json
+++ b/packages/data/data/recipes/youtube-channel/make-and-drink/banana-oleo-daiquiri.json
@@ -22,18 +22,18 @@
       }
     },
     {
-      "name": "Two James Doctor Bird rum",
-      "type": "spirit",
-      "quantity": {
-        "amount": 1.5,
-        "unit": "oz"
-      }
-    },
-    {
       "name": "Planteray OFTD",
       "type": "spirit",
       "quantity": {
         "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Two James Doctor Bird rum",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
         "unit": "oz"
       }
     }

--- a/packages/data/data/recipes/youtube-channel/make-and-drink/old-ironsides.json
+++ b/packages/data/data/recipes/youtube-channel/make-and-drink/old-ironsides.json
@@ -58,7 +58,7 @@
     },
     {
       "relation": "bar",
-      "source": "Death & Co.",
+      "source": "Death & Co",
       "location": "New York, NY"
     }
   ],

--- a/packages/data/data/recipes/youtube-channel/spike-breezeway-cocktail-hour/last-rites.json
+++ b/packages/data/data/recipes/youtube-channel/spike-breezeway-cocktail-hour/last-rites.json
@@ -46,7 +46,7 @@
   "attributions": [
     {
       "relation": "recipe author",
-      "source": "Mariano Licuidine"
+      "source": "Mariano Licudine"
     },
     {
       "relation": "bar",

--- a/packages/data/data/recipes/youtube-channel/spike-breezeway-cocktail-hour/the-monkey-pod.json
+++ b/packages/data/data/recipes/youtube-channel/spike-breezeway-cocktail-hour/the-monkey-pod.json
@@ -6,18 +6,18 @@
   "glassware": "old fashioned",
   "ingredients": [
     {
-      "name": "Lime juice",
-      "type": "juice",
+      "name": "coconut cream",
+      "type": "other",
       "quantity": {
-        "amount": 0.75,
+        "amount": 0.5,
         "unit": "oz"
       }
     },
     {
-      "name": "Coconut cream",
-      "type": "other",
+      "name": "Lime juice",
+      "type": "juice",
       "quantity": {
-        "amount": 0.5,
+        "amount": 0.75,
         "unit": "oz"
       }
     },

--- a/packages/data/tools/check-data.ts
+++ b/packages/data/tools/check-data.ts
@@ -431,10 +431,8 @@ logger.footer('Done!');
 logger.header('👥 Checking for similar author and bar names...');
 
 const authorNames = Array.from(authorNameUsages.keys());
-for (let i = 0; i < authorNames.length; i++) {
-  for (let j = i + 1; j < authorNames.length; j++) {
-    const a = authorNames[i]!,
-      b = authorNames[j]!;
+for (const [i, a] of authorNames.entries()) {
+  for (const b of authorNames.slice(i + 1)) {
     if (areSimilarNames(a, b)) {
       const filesA = authorNameUsages.get(a)!;
       const filesB = authorNameUsages.get(b)!;
@@ -448,10 +446,8 @@ for (let i = 0; i < authorNames.length; i++) {
 }
 
 const barKeys = Array.from(barNameCasings.keys());
-for (let i = 0; i < barKeys.length; i++) {
-  for (let j = i + 1; j < barKeys.length; j++) {
-    const a = barKeys[i]!,
-      b = barKeys[j]!;
+for (const [i, a] of barKeys.entries()) {
+  for (const b of barKeys.slice(i + 1)) {
     if (areSimilarNames(a, b)) {
       const casingsA = barNameCasings.get(a)!;
       const casingsB = barNameCasings.get(b)!;

--- a/packages/data/tools/check-data.ts
+++ b/packages/data/tools/check-data.ts
@@ -437,9 +437,9 @@ for (const [i, a] of authorNames.entries()) {
       const filesA = authorNameUsages.get(a)!;
       const filesB = authorNameUsages.get(b)!;
       logger.warn(
-        `Similar author names — possible misspelling:\n` +
-          `  "${a}" (${filesA.length} recipe(s)) vs "${b}" (${filesB.length} recipe(s))\n` +
-          `  Review and standardize spelling. If genuinely different people, this is a false positive.`,
+        `Similar author names — possible misspelling:`,
+        `"${a}" (${filesA.length} recipe(s)) vs "${b}" (${filesB.length} recipe(s))`,
+        `Review and standardize spelling. If genuinely different people, this is a false positive.`,
       );
     }
   }
@@ -456,9 +456,9 @@ for (const [i, a] of barKeys.entries()) {
       const countA = Array.from(casingsA.values()).flat().length;
       const countB = Array.from(casingsB.values()).flat().length;
       logger.warn(
-        `Similar bar names — possible misspelling:\n` +
-          `  "${displayA}" (${countA} recipe(s)) vs "${displayB}" (${countB} recipe(s))\n` +
-          `  Review and standardize spelling. If genuinely different bars, this is a false positive.`,
+        `Similar bar names — possible misspelling:`,
+        `"${displayA}" (${countA} recipe(s)) vs "${displayB}" (${countB} recipe(s))`,
+        `Review and standardize spelling. If genuinely different bars, this is a false positive.`,
       );
     }
   }

--- a/packages/data/tools/check-data.ts
+++ b/packages/data/tools/check-data.ts
@@ -12,6 +12,7 @@ import slugify from '@sindresorhus/slugify';
 import Ajv from 'ajv/dist/2020.js';
 import { isChapterFolder } from '../src/modules/chapters.ts';
 import { logger } from './cli-util.ts';
+import { areSimilarNames } from './name-similarity.ts';
 
 const startTime = performance.now();
 const PACKAGE_ROOT = path.join(import.meta.dirname, '..');
@@ -134,6 +135,10 @@ logger.footer('Done!');
 // Maps lowercase name -> Map of exact casing -> list of files using that casing
 const barNameCasings = new Map<string, Map<string, string[]>>();
 
+// Track author/adapted-by names for similarity detection
+// Maps name -> list of recipe files using that name
+const authorNameUsages = new Map<string, string[]>();
+
 logger.header('🔍 Validating data files...');
 const dataGlob = path.join(PACKAGE_ROOT, 'data/**/*.json');
 for await (const sourceFile of fs.glob(dataGlob)) {
@@ -248,6 +253,11 @@ for await (const sourceFile of fs.glob(dataGlob)) {
               `Split into separate attributions, one per person.`,
           );
         }
+
+        if (!authorNameUsages.has(attribution.source)) {
+          authorNameUsages.set(attribution.source, []);
+        }
+        authorNameUsages.get(attribution.source)!.push(sourceFile);
       }
     }
   }
@@ -415,6 +425,49 @@ for (const [, casings] of barNameCasings) {
     fail(`Bar name has inconsistent casing: ${variants}`);
   }
 }
+logger.footer('Done!');
+
+// Check for similar author and bar names (possible misspellings)
+logger.header('👥 Checking for similar author and bar names...');
+
+const authorNames = Array.from(authorNameUsages.keys());
+for (let i = 0; i < authorNames.length; i++) {
+  for (let j = i + 1; j < authorNames.length; j++) {
+    const a = authorNames[i]!,
+      b = authorNames[j]!;
+    if (areSimilarNames(a, b)) {
+      const filesA = authorNameUsages.get(a)!;
+      const filesB = authorNameUsages.get(b)!;
+      logger.warn(
+        `Similar author names — possible misspelling:\n` +
+          `  "${a}" (${filesA.length} recipe(s)) vs "${b}" (${filesB.length} recipe(s))\n` +
+          `  Review and standardize spelling. If genuinely different people, this is a false positive.`,
+      );
+    }
+  }
+}
+
+const barKeys = Array.from(barNameCasings.keys());
+for (let i = 0; i < barKeys.length; i++) {
+  for (let j = i + 1; j < barKeys.length; j++) {
+    const a = barKeys[i]!,
+      b = barKeys[j]!;
+    if (areSimilarNames(a, b)) {
+      const casingsA = barNameCasings.get(a)!;
+      const casingsB = barNameCasings.get(b)!;
+      const displayA = Array.from(casingsA.keys())[0] ?? a;
+      const displayB = Array.from(casingsB.keys())[0] ?? b;
+      const countA = Array.from(casingsA.values()).flat().length;
+      const countB = Array.from(casingsB.values()).flat().length;
+      logger.warn(
+        `Similar bar names — possible misspelling:\n` +
+          `  "${displayA}" (${countA} recipe(s)) vs "${displayB}" (${countB} recipe(s))\n` +
+          `  Review and standardize spelling. If genuinely different bars, this is a false positive.`,
+      );
+    }
+  }
+}
+
 logger.footer('Done!');
 
 // Validate book chapter structure

--- a/packages/data/tools/cli-util.ts
+++ b/packages/data/tools/cli-util.ts
@@ -2,59 +2,40 @@
  * Shared CLI utilities for tools
  */
 
+function withContinuation(prefix: string, ...messages: string[]): string {
+  const lines = messages.flatMap((m) => m.split('\n'));
+  return lines.map((line, i) => (i === 0 ? `${prefix}${line}` : `│ ${line}`)).join('\n');
+}
+
 export const logger = {
-  /**
-   * Log a section header
-   */
   header(message: string): void {
     console.log(`╭ ${message}`);
   },
 
-  /**
-   * Log a section item
-   */
-  item(message: string): void {
-    console.log(`├ ${message}`);
+  item(...messages: string[]): void {
+    console.log(withContinuation('├ ', ...messages));
   },
 
-  /**
-   * Log a section footer
-   */
   footer(message = 'Done!'): void {
     console.log(`╰ ${message}\n`);
   },
 
-  /**
-   * Log an error message
-   */
-  error(message: string): void {
-    console.error(`├ ❌ ${message}`);
+  error(...messages: string[]): void {
+    console.error(withContinuation('├ ❌ ', ...messages));
   },
 
-  /**
-   * Log a change message
-   */
-  change(message: string): void {
-    console.log(`├ 🔄 ${message}`);
+  change(...messages: string[]): void {
+    console.log(withContinuation('├ 🔄 ', ...messages));
   },
 
-  /**
-   * Log a success message
-   */
   success(message: string): void {
     console.log(`✅ ${message}`);
   },
 
-  /**
-   * Log a warning message (visible but does not fail the check)
-   */
-  warn(message: string): void {
-    console.warn(`├ ⚠️  ${message}`);
+  warn(...messages: string[]): void {
+    console.warn(withContinuation('├ ⚠️  ', ...messages));
   },
 
-  /**
-   * Log a failure message
-   */
   failure(message: string): void {
     console.log(`❌ ${message}`);
   },

--- a/packages/data/tools/cli-util.ts
+++ b/packages/data/tools/cli-util.ts
@@ -46,6 +46,13 @@ export const logger = {
   },
 
   /**
+   * Log a warning message (visible but does not fail the check)
+   */
+  warn(message: string): void {
+    console.warn(`├ ⚠️  ${message}`);
+  },
+
+  /**
    * Log a failure message
    */
   failure(message: string): void {

--- a/packages/data/tools/name-similarity.test.ts
+++ b/packages/data/tools/name-similarity.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { areSimilarNames, levenshtein } from './name-similarity';
+
+describe('levenshtein', () => {
+  it('returns 0 for identical strings', () => {
+    expect(levenshtein('Death Co', 'Death Co')).toBe(0);
+    expect(levenshtein('', '')).toBe(0);
+  });
+
+  it('counts single insertion', () => {
+    expect(levenshtein('Jared', 'Jarred')).toBe(1);
+  });
+
+  it('counts single substitution', () => {
+    expect(levenshtein('Mariano Licudine', 'Mariano Licuidine')).toBe(1);
+  });
+
+  it('counts two edits for Javel Taft vs Javelle Taft', () => {
+    expect(levenshtein('Javel Taft', 'Javelle Taft')).toBe(2);
+  });
+
+  it('counts two edits for Death Co vs Deatch Co.', () => {
+    expect(levenshtein('Death Co', 'Deatch Co.')).toBe(2);
+  });
+
+  it('returns high distance for completely different strings', () => {
+    expect(levenshtein('John Smith', 'Jane Doe')).toBeGreaterThan(4);
+  });
+});
+
+describe('areSimilarNames', () => {
+  it('detects all known real-world duplicate pairs', () => {
+    expect(areSimilarNames('Jared Weigand', 'Jarred Weigand')).toBe(true);
+    expect(areSimilarNames('Javel Taft', 'Javelle Taft')).toBe(true);
+    expect(areSimilarNames('Mariano Licudine', 'Mariano Licuidine')).toBe(true);
+    expect(areSimilarNames('Death Co', 'Deatch Co.')).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(areSimilarNames('jared weigand', 'Jarred Weigand')).toBe(true);
+  });
+
+  it('returns false for identical strings', () => {
+    expect(areSimilarNames('Jared Weigand', 'Jared Weigand')).toBe(false);
+  });
+
+  it('returns false for same string with different casing', () => {
+    expect(areSimilarNames('Death Co', 'death co')).toBe(false);
+  });
+
+  it('returns false for clearly different names', () => {
+    expect(areSimilarNames('John Smith', 'Jane Doe')).toBe(false);
+    expect(areSimilarNames('Hemingway', 'Smugglers Cove')).toBe(false);
+  });
+
+  it('returns false for very short names (below min length guard)', () => {
+    expect(areSimilarNames('Bob', 'Rob')).toBe(false);
+    expect(areSimilarNames('Ann', 'Ian')).toBe(false);
+  });
+
+  it('returns false when edit distance exceeds threshold', () => {
+    expect(areSimilarNames('Giuseppe Gonzalez', 'Abigail Guimaraes')).toBe(false);
+  });
+});

--- a/packages/data/tools/name-similarity.ts
+++ b/packages/data/tools/name-similarity.ts
@@ -1,6 +1,6 @@
 export function levenshtein(a: string, b: string): number {
-  const m = a.length,
-    n = b.length;
+  const m = a.length;
+  const n = b.length;
   const dp: number[][] = Array.from({ length: m + 1 }, (_, i) =>
     Array.from({ length: n + 1 }, (_, j) => (i === 0 ? j : j === 0 ? i : 0)),
   );
@@ -14,8 +14,8 @@ export function levenshtein(a: string, b: string): number {
 }
 
 export function areSimilarNames(a: string, b: string): boolean {
-  const la = a.toLowerCase(),
-    lb = b.toLowerCase();
+  const la = a.toLowerCase();
+  const lb = b.toLowerCase();
   if (la === lb) return false;
   if (Math.min(la.length, lb.length) < 4) return false;
   const dist = levenshtein(la, lb);

--- a/packages/data/tools/name-similarity.ts
+++ b/packages/data/tools/name-similarity.ts
@@ -1,0 +1,23 @@
+export function levenshtein(a: string, b: string): number {
+  const m = a.length,
+    n = b.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, (_, i) =>
+    Array.from({ length: n + 1 }, (_, j) => (i === 0 ? j : j === 0 ? i : 0)),
+  );
+  for (let i = 1; i <= m; i++)
+    for (let j = 1; j <= n; j++)
+      dp[i]![j] =
+        a[i - 1] === b[j - 1]
+          ? dp[i - 1]![j - 1]!
+          : 1 + Math.min(dp[i - 1]![j]!, dp[i]![j - 1]!, dp[i - 1]![j - 1]!);
+  return dp[m]![n]!;
+}
+
+export function areSimilarNames(a: string, b: string): boolean {
+  const la = a.toLowerCase(),
+    lb = b.toLowerCase();
+  if (la === lb) return false;
+  if (Math.min(la.length, lb.length) < 4) return false;
+  const dist = levenshtein(la, lb);
+  return dist > 0 && dist <= 2 && dist / Math.max(la.length, lb.length) <= 0.25;
+}


### PR DESCRIPTION
## Summary

- Adds Levenshtein-based fuzzy matching to `yarn check-data` that warns (⚠️, non-blocking) when two author or bar names are within 2 edits and less than 25% different in length — surfacing likely misspellings without failing the check for genuine false positives (e.g. Trey Jenkins vs Carey Jenkins)
- Extracts the helpers into `packages/data/tools/name-similarity.ts` with 13 unit tests covering the real-world duplicate pairs and negative cases
- Fixes all duplicate spellings found by the new check: Jared→Jarred Weigand (9 recipes), Javel→Javelle Taft (2), Mariano Licuidine→Licudine (1), Death & Co.→Death & Co (3)

## Test plan

- [ ] `yarn vitest --run` — 343 tests pass
- [ ] `yarn check-data` — passes with a single ⚠️ warning for Trey Jenkins / Carey Jenkins (false positive, different people)
- [ ] `yarn lint` — no TypeScript errors