### PR TITLE
[codex] Silence YouTube embed test warnings

### DIFF
--- a/apps/web/testing/setup-component.ts
+++ b/apps/web/testing/setup-component.ts
@@ -3,3 +3,4 @@ import { vi } from 'vitest';
 
 vi.mock('next/router', async () => import('next-router-mock'));
 vi.mock('next/navigation', async () => import('next-router-mock/navigation'));
+vi.mock('lite-youtube-embed', () => ({}));

--- a/apps/web/testing/setup-page.ts
+++ b/apps/web/testing/setup-page.ts
@@ -7,6 +7,7 @@ import { vi } from 'vitest';
 
 vi.mock('next/router', async () => import('next-router-mock'));
 vi.mock('next/navigation', async () => import('next-router-mock/navigation'));
+vi.mock('lite-youtube-embed', () => ({}));
 
 // In Node.js 25+, the global localStorage is a built-in that lacks the full
 // Web Storage API (e.g. no clear()). Replace it with happy-dom's implementation.


### PR DESCRIPTION
## Summary

- Mock `lite-youtube-embed` in Happy DOM test setup files.
- Prevent the browser-only custom element side effect from appending YouTube iframes during Vitest runs.

## Why

`lite-youtube-embed` registers a custom element that appends a `<noscript>` iframe when rendered. Happy DOM has iframe page loading disabled in this test environment and reports that as a `NotSupportedError`, even though the tests pass. Mocking the side-effect import keeps tests focused on app rendering and removes the noisy warning.

## Validation

- `corepack yarn vitest --run`
- `corepack yarn oxfmt apps/web/testing/setup-component.ts apps/web/testing/setup-page.ts --check`
- `corepack yarn lint`
- pre-push hook: route types, formatting, `vitest --run --coverage`
