### PR TITLE
Fix duplicate ingredient slugs

### DIFF
--- a/packages/data/data/ingredients/liqueur/bonal-gentiane-quina.json
+++ b/packages/data/data/ingredients/liqueur/bonal-gentiane-quina.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "../../../schemas/ingredient.schema.json",
-  "name": "Bonal Gentiane-Quina",
-  "type": "liqueur",
-  "categories": ["Quinquina"]
-}

--- a/packages/data/data/ingredients/wine/pimms-no-1.json
+++ b/packages/data/data/ingredients/wine/pimms-no-1.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "../../../schemas/ingredient.schema.json",
-  "name": "Pimm's No.1",
-  "type": "wine"
-}

--- a/packages/data/data/recipes/book/death-co-welcome-home/01_Fresh & Lively (Highball)/harlequin.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/01_Fresh & Lively (Highball)/harlequin.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "Bonal Gentiane-Quina",
-      "type": "liqueur",
+      "type": "wine",
       "quantity": {
         "amount": 1.5,
         "unit": "oz"

--- a/packages/data/data/recipes/book/death-co-welcome-home/02_Light & Playful (Daiquiri)/cruel-to-be-kind.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/02_Light & Playful (Daiquiri)/cruel-to-be-kind.json
@@ -27,7 +27,7 @@
     },
     {
       "name": "Bonal Gentiane-Quina",
-      "type": "liqueur",
+      "type": "wine",
       "quantity": { "amount": 0.5, "unit": "oz" }
     },
     {

--- a/packages/data/data/recipes/book/death-co-welcome-home/02_Light & Playful (Daiquiri)/inspector-norse.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/02_Light & Playful (Daiquiri)/inspector-norse.json
@@ -63,7 +63,7 @@
     },
     {
       "name": "Pimm's No.1",
-      "type": "wine",
+      "type": "liqueur",
       "quantity": {
         "amount": 1,
         "unit": "oz"

--- a/packages/data/data/recipes/book/death-co-welcome-home/05_Elegant & Graceful (Martini)/game-loves-game.json
+++ b/packages/data/data/recipes/book/death-co-welcome-home/05_Elegant & Graceful (Martini)/game-loves-game.json
@@ -36,7 +36,7 @@
     },
     {
       "name": "Bonal Gentiane-Quina",
-      "type": "liqueur",
+      "type": "wine",
       "quantity": {
         "amount": 0.25,
         "unit": "oz"

--- a/packages/data/tools/check-data.ts
+++ b/packages/data/tools/check-data.ts
@@ -121,12 +121,24 @@ for await (const categoryFile of fs.glob(categoriesGlob)) {
 logger.item(`Found ${categorySlugs.size} categories`);
 
 const ingredientFolders = new Map<string, string>(); // slug -> folder type
+const ingredientFiles = new Map<string, string>(); // slug -> filepath
 const ingredientsGlob = path.join(PACKAGE_ROOT, 'data/ingredients/**/*.json');
 for await (const ingredientFile of fs.glob(ingredientsGlob)) {
   const data = JSON.parse(await fs.readFile(ingredientFile, 'utf-8'));
   const folderType = path.basename(path.dirname(ingredientFile));
-  canonicalNames.set(slugify(data.name), data.name);
-  ingredientFolders.set(slugify(data.name), folderType);
+  const ingredientSlug = slugify(data.name);
+
+  const existingIngredientFile = ingredientFiles.get(ingredientSlug);
+  if (existingIngredientFile) {
+    fail(
+      `Duplicate ingredient slug "${ingredientSlug}" in ${ingredientFile} and ${existingIngredientFile}`,
+    );
+    continue;
+  }
+
+  canonicalNames.set(ingredientSlug, data.name);
+  ingredientFolders.set(ingredientSlug, folderType);
+  ingredientFiles.set(ingredientSlug, ingredientFile);
 }
 logger.item(`Collected ${canonicalNames.size} canonical names`);
 logger.footer('Done!');
@@ -358,6 +370,8 @@ for await (const sourceFile of fs.glob(dataGlob)) {
           name: ingredient.name,
           type: ingredient.type,
         });
+        ingredientFolders.set(slugify(ingredient.name), ingredient.type);
+        ingredientFiles.set(slugify(ingredient.name), ingredientPath);
         fail(`Created ${ingredientPath} - review and add details if needed`);
       }
     }


### PR DESCRIPTION
## Summary
- remove duplicate Bonal Gentiane-Quina and Pimm's No.1 ingredient metadata files
- update affected recipes to reference the remaining ingredient type
- make `check-data` fail when ingredient metadata repeats a slug across files

## Why
Ingredient slugs are expected to be globally unique. These two duplicates made recipe type checks ambiguous, so the data should be normalized and the validator should catch future overlap directly.

## Validation
- `corepack yarn check-data`
- duplicate ingredient scan reports `duplicates=0`
- `corepack yarn vitest --run packages/jsonschema-formatter/src/formatter.test.ts packages/ingredient-sorting/src/ingredientSorting.test.ts packages/data/src/modules/chapters.test.ts`
- `corepack yarn lint`
- pre-push hook ran `yarn lint && yarn test` successfully while pushing
