### PR TITLE
[codex] Speed up page tests with real data fixtures

### DIFF
--- a/apps/web/app/category/[slug]/page.test.tsx
+++ b/apps/web/app/category/[slug]/page.test.tsx
@@ -1,7 +1,38 @@
+import { getChildCategories } from '@cocktails/data/categories';
+import type * as CategoriesModule from '@cocktails/data/categories';
+import { getIngredient, getIngredientsForCategory } from '@cocktails/data/ingredients';
+import type * as IngredientsModule from '@cocktails/data/ingredients';
+import { getRecipe, getRecipeByCategory } from '@cocktails/data/recipes';
+import type * as RecipesModule from '@cocktails/data/recipes';
 import { screen } from '@testing-library/react';
-import { vi, describe, it, expect } from 'vitest';
+import { vi, beforeEach, describe, it, expect } from 'vitest';
 import { setupApp } from '#/testing';
 import CategoryPage from './page';
+
+vi.mock('@cocktails/data/categories', async (importOriginal) => ({
+  ...(await importOriginal<typeof CategoriesModule>()),
+  getChildCategories: vi.fn(),
+}));
+vi.mock('@cocktails/data/ingredients', async (importOriginal) => ({
+  ...(await importOriginal<typeof IngredientsModule>()),
+  getIngredientsForCategory: vi.fn(),
+}));
+vi.mock('@cocktails/data/recipes', async (importOriginal) => ({
+  ...(await importOriginal<typeof RecipesModule>()),
+  getRecipeByCategory: vi.fn(),
+}));
+
+const testMembers = [await getIngredient('spirit', 'beefeater-london-dry-gin')];
+const testRecipes = await Promise.all([
+  getRecipe({ type: 'book', slug: 'easy-tiki' }, 'fog-cutter', '01_Classic Recipes'),
+  getRecipe({ type: 'youtube-channel', slug: 'anders-erickson' }, 'cloister'),
+]);
+
+beforeEach(() => {
+  vi.mocked(getChildCategories).mockResolvedValue([]);
+  vi.mocked(getIngredientsForCategory).mockResolvedValue([testMembers, []]);
+  vi.mocked(getRecipeByCategory).mockResolvedValue(testRecipes);
+});
 
 describe('CategoryPage', () => {
   describe('basic rendering', () => {

--- a/apps/web/app/ingredient/[type]/[slug]/page.test.tsx
+++ b/apps/web/app/ingredient/[type]/[slug]/page.test.tsx
@@ -1,7 +1,20 @@
+import {
+  getIngredient,
+  getRecipesForIngredient,
+  getSubstitutesForIngredient,
+} from '@cocktails/data/ingredients';
+import type * as IngredientsModule from '@cocktails/data/ingredients';
+import { getRecipe } from '@cocktails/data/recipes';
 import { screen } from '@testing-library/react';
-import { vi, describe, it, expect, beforeAll } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import { setupApp } from '#/testing';
 import IngredientPage from './page';
+
+vi.mock('@cocktails/data/ingredients', async (importOriginal) => ({
+  ...(await importOriginal<typeof IngredientsModule>()),
+  getRecipesForIngredient: vi.fn(),
+  getSubstitutesForIngredient: vi.fn(),
+}));
 
 // Using real pineapple-juice ingredient which has:
 // - Multiple recipes (39+)
@@ -20,20 +33,49 @@ const TEST_SPIRIT = {
   name: 'Beefeater London Dry Gin',
 };
 
-// Cache page JSX once for the entire file to avoid repeated async data loading
-let ingredientPageJSX: Awaited<ReturnType<typeof IngredientPage>>;
-let spiritPageJSX: Awaited<ReturnType<typeof IngredientPage>>;
+const [pineappleRecipes, spiritRecipes, substitutes] = await Promise.all([
+  Promise.all([
+    getRecipe(
+      { type: 'book', slug: 'smugglers-cove' },
+      'jungle-bird',
+      '03_The Tiki Revival',
+    ),
+    getRecipe(
+      { type: 'book', slug: 'tiki-modern-tropical-cocktails' },
+      'jungle-bird',
+      '02_Essential Tiki Classics',
+    ),
+    getRecipe(
+      { type: 'book', slug: 'smugglers-cove' },
+      'chartreuse-swizzle',
+      '04_Creating the Space',
+    ),
+  ]),
+  Promise.all([
+    getRecipe({ type: 'youtube-channel', slug: 'anders-erickson' }, 'cloister'),
+  ]),
+  Promise.all([getIngredient('spirit', 'fords-gin')]),
+]);
 
-beforeAll(async () => {
-  [ingredientPageJSX, spiritPageJSX] = await Promise.all([
-    IngredientPage({
-      params: Promise.resolve({ type: TEST_INGREDIENT.type, slug: TEST_INGREDIENT.slug }),
-    }),
-    IngredientPage({
-      params: Promise.resolve({ type: TEST_SPIRIT.type, slug: TEST_SPIRIT.slug }),
-    }),
-  ]);
+vi.mocked(getRecipesForIngredient).mockImplementation(async (ingredient) => {
+  if (ingredient.slug === TEST_INGREDIENT.slug) return pineappleRecipes;
+  if (ingredient.slug === TEST_SPIRIT.slug) return spiritRecipes;
+  return [];
 });
+vi.mocked(getSubstitutesForIngredient).mockImplementation(async (ingredient) => {
+  if (ingredient.slug === TEST_SPIRIT.slug) return substitutes;
+  return [];
+});
+
+// Cache page JSX once for the entire file to avoid repeated async data loading
+const [ingredientPageJSX, spiritPageJSX] = await Promise.all([
+  IngredientPage({
+    params: Promise.resolve({ type: TEST_INGREDIENT.type, slug: TEST_INGREDIENT.slug }),
+  }),
+  IngredientPage({
+    params: Promise.resolve({ type: TEST_SPIRIT.type, slug: TEST_SPIRIT.slug }),
+  }),
+]);
 
 describe('IngredientPage', () => {
   describe('basic rendering', () => {

--- a/apps/web/app/list/authors/page.test.tsx
+++ b/apps/web/app/list/authors/page.test.tsx
@@ -1,11 +1,35 @@
+import { getAllRecipes, getRecipe } from '@cocktails/data/recipes';
+import type * as RecipesModule from '@cocktails/data/recipes';
 import { screen, within } from '@testing-library/react';
-import { vi, describe, it, expect } from 'vitest';
+import { vi, beforeEach, describe, it, expect } from 'vitest';
 import { getAuthorRecipesUrl } from '#/modules/url';
 import { setupApp } from '#/testing';
 import AuthorListPage from './page';
 
+vi.mock('@cocktails/data/recipes', async (importOriginal) => ({
+  ...(await importOriginal<typeof RecipesModule>()),
+  getAllRecipes: vi.fn(),
+}));
+
 // Real author from the codebase with multiple recipes
 const KNOWN_AUTHOR = 'Garret Richard';
+
+const testRecipes = await Promise.all([
+  getRecipe(
+    { type: 'book', slug: 'tropical-standard' },
+    'daiquiri',
+    '02_Preparations - Shaken - Up',
+  ),
+  getRecipe(
+    { type: 'book', slug: 'tropical-standard' },
+    'mojito',
+    '04_Preparations - Shaken - Collins',
+  ),
+]);
+
+beforeEach(() => {
+  vi.mocked(getAllRecipes).mockResolvedValue(testRecipes);
+});
 
 describe('AuthorListPage', () => {
   it('shows search input, title and list', async () => {

--- a/apps/web/app/list/bars/page.test.tsx
+++ b/apps/web/app/list/bars/page.test.tsx
@@ -1,11 +1,35 @@
+import { getAllRecipes, getRecipe } from '@cocktails/data/recipes';
+import type * as RecipesModule from '@cocktails/data/recipes';
 import { screen, within } from '@testing-library/react';
-import { vi, describe, it, expect } from 'vitest';
+import { vi, beforeEach, describe, it, expect } from 'vitest';
 import { getBarRecipesUrl } from '#/modules/url';
 import { setupApp } from '#/testing';
 import BarListPage from './page';
 
+vi.mock('@cocktails/data/recipes', async (importOriginal) => ({
+  ...(await importOriginal<typeof RecipesModule>()),
+  getAllRecipes: vi.fn(),
+}));
+
 // Real bar data from the codebase
 const TEST_BAR = { name: 'Sunken Harbor Club', location: 'Brooklyn, NY' };
+
+const testRecipes = await Promise.all([
+  getRecipe(
+    { type: 'book', slug: 'tropical-standard' },
+    'daiquiri',
+    '02_Preparations - Shaken - Up',
+  ),
+  getRecipe(
+    { type: 'book', slug: 'tropical-standard' },
+    'mojito',
+    '04_Preparations - Shaken - Collins',
+  ),
+]);
+
+beforeEach(() => {
+  vi.mocked(getAllRecipes).mockResolvedValue(testRecipes);
+});
 
 describe('BarListPage', () => {
   it('shows search input, title and list', async () => {

--- a/apps/web/app/list/bottles/page.test.tsx
+++ b/apps/web/app/list/bottles/page.test.tsx
@@ -1,8 +1,28 @@
-import { getAllIngredients } from '@cocktails/data/ingredients';
+import { getAllIngredients, getIngredient } from '@cocktails/data/ingredients';
+import type * as IngredientsModule from '@cocktails/data/ingredients';
 import { screen, within } from '@testing-library/react';
-import { vi, describe, it, expect } from 'vitest';
+import { vi, beforeEach, describe, it, expect } from 'vitest';
 import { setupApp } from '#/testing';
 import BottlesPage from './page';
+
+vi.mock('@cocktails/data/ingredients', async (importOriginal) => ({
+  ...(await importOriginal<typeof IngredientsModule>()),
+  getAllIngredients: vi.fn(),
+}));
+
+const testIngredients = await Promise.all([
+  getIngredient('spirit', 'aberfeldy-12-year'),
+  getIngredient('spirit', 'appleton-signature'),
+  getIngredient('spirit', 'grey-goose-vodka'),
+  getIngredient('liqueur', 'campari'),
+  getIngredient('juice', 'apple-juice'),
+  getIngredient('juice', 'lime-juice'),
+  getIngredient('soda', 'ginger-beer'),
+]);
+
+beforeEach(() => {
+  vi.mocked(getAllIngredients).mockResolvedValue(testIngredients);
+});
 
 describe('BottlesPage', () => {
   it('shows search input, title and list', async () => {
@@ -40,9 +60,9 @@ describe('BottlesPage', () => {
       nuqsOptions: { searchParams: { search: 'rum' } },
     });
 
-    // Initially filtered
+    // Initially filtered through a real category name on Appleton Signature.
     const resultList = screen.getByRole('list');
-    expect(resultList).toHaveTextContent(/rum/i);
+    expect(resultList).toHaveTextContent('Appleton Signature');
 
     // Clear the search input
     const input = screen.getByRole('searchbox');

--- a/apps/web/app/list/ingredients/page.test.tsx
+++ b/apps/web/app/list/ingredients/page.test.tsx
@@ -1,10 +1,36 @@
-import { getAllCategories } from '@cocktails/data/categories';
-import { getAllIngredients } from '@cocktails/data/ingredients';
+import { getAllCategories, getCategory } from '@cocktails/data/categories';
+import type * as CategoriesModule from '@cocktails/data/categories';
+import { getAllIngredients, getIngredient } from '@cocktails/data/ingredients';
+import type * as IngredientsModule from '@cocktails/data/ingredients';
 import { screen, within } from '@testing-library/react';
-import { vi, describe, it, expect } from 'vitest';
+import { vi, beforeEach, describe, it, expect } from 'vitest';
 import { getCategoryUrl } from '#/modules/url';
 import { setupApp } from '#/testing';
 import IngredientsPage from './page';
+
+vi.mock('@cocktails/data/categories', async (importOriginal) => ({
+  ...(await importOriginal<typeof CategoriesModule>()),
+  getAllCategories: vi.fn(),
+}));
+vi.mock('@cocktails/data/ingredients', async (importOriginal) => ({
+  ...(await importOriginal<typeof IngredientsModule>()),
+  getAllIngredients: vi.fn(),
+}));
+
+const testIngredients = await Promise.all([
+  getIngredient('juice', 'apple-juice'),
+  getIngredient('juice', 'lime-juice'),
+  getIngredient('soda', 'ginger-beer'),
+  getIngredient('liqueur', 'campari'),
+  getIngredient('spirit', 'aberfeldy-12-year'),
+  getIngredient('spirit', 'appleton-signature'),
+]);
+const testCategories = await Promise.all([getCategory('aged-rum'), getCategory('gin')]);
+
+beforeEach(() => {
+  vi.mocked(getAllIngredients).mockResolvedValue(testIngredients);
+  vi.mocked(getAllCategories).mockResolvedValue(testCategories);
+});
 
 describe('IngredientsPage', () => {
   it('shows search input, title and list', async () => {

--- a/apps/web/app/source/[type]/[name]/page.test.tsx
+++ b/apps/web/app/source/[type]/[name]/page.test.tsx
@@ -1,7 +1,14 @@
+import { getRecipe, getRecipesFromSource } from '@cocktails/data/recipes';
+import type * as RecipesModule from '@cocktails/data/recipes';
 import { screen } from '@testing-library/react';
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, beforeEach, describe, it, expect } from 'vitest';
 import { setupApp } from '#/testing';
 import SourcePage from './page';
+
+vi.mock('@cocktails/data/recipes', async (importOriginal) => ({
+  ...(await importOriginal<typeof RecipesModule>()),
+  getRecipesFromSource: vi.fn(),
+}));
 
 // Using Anders Erickson YouTube channel as the main test source
 const TEST_YOUTUBE = {
@@ -16,6 +23,72 @@ const TEST_YOUTUBE_ALT = {
   slug: 'educated-barfly',
   name: 'The Educated Barfly',
 };
+
+const [andersRecipes, educatedBarflyRecipes, smugglersCoveRecipes, sippinSafariRecipes] =
+  await Promise.all([
+    Promise.all([
+      getRecipe({ type: 'youtube-channel', slug: 'anders-erickson' }, 'mezcal-margarita'),
+      getRecipe({ type: 'youtube-channel', slug: 'anders-erickson' }, 'daiquiri'),
+    ]),
+    Promise.all([
+      getRecipe(
+        { type: 'youtube-channel', slug: 'educated-barfly' },
+        'hot-diggity-daiquiri',
+      ),
+    ]),
+    Promise.all([
+      getRecipe(
+        { type: 'book', slug: 'smugglers-cove' },
+        'aku-aku',
+        '01_The Birth of Tiki',
+      ),
+      getRecipe(
+        { type: 'book', slug: 'smugglers-cove' },
+        'pupule',
+        '01_The Birth of Tiki',
+      ),
+      getRecipe(
+        { type: 'book', slug: 'smugglers-cove' },
+        'three-dots-and-a-dash',
+        '01_The Birth of Tiki',
+      ),
+      getRecipe(
+        { type: 'book', slug: 'smugglers-cove' },
+        'suffering-bastard',
+        '02_The Golden Era',
+      ),
+      getRecipe(
+        { type: 'book', slug: 'smugglers-cove' },
+        'zombie',
+        '09_Eight Essential Exotic Elixirs',
+      ),
+    ]),
+    Promise.all([getRecipe({ type: 'book', slug: 'sippin-safari' }, 'caribbean-punch')]),
+  ]);
+
+beforeEach(() => {
+  vi.mocked(getRecipesFromSource).mockImplementation(async (source) => {
+    if (source.type === TEST_YOUTUBE.type && source.slug === TEST_YOUTUBE.slug) {
+      return andersRecipes;
+    }
+    if (source.type === TEST_YOUTUBE_ALT.type && source.slug === TEST_YOUTUBE_ALT.slug) {
+      return educatedBarflyRecipes;
+    }
+    if (
+      source.type === TEST_BOOK_WITH_CHAPTERS.type &&
+      source.slug === TEST_BOOK_WITH_CHAPTERS.slug
+    ) {
+      return smugglersCoveRecipes;
+    }
+    if (
+      source.type === TEST_BOOK_WITHOUT_CHAPTERS.type &&
+      source.slug === TEST_BOOK_WITHOUT_CHAPTERS.slug
+    ) {
+      return sippinSafariRecipes;
+    }
+    return [];
+  });
+});
 
 describe('SourcePage', () => {
   describe('basic rendering', () => {

--- a/apps/web/testing/index.tsx
+++ b/apps/web/testing/index.tsx
@@ -19,8 +19,13 @@ export function setupApp(
   ui: ReactNode,
   { nuqsOptions, routerOptions, ...renderOptions }: NuqsRenderOptions = {},
 ) {
+  let user: ReturnType<typeof userEvent.setup> | undefined;
+
   return {
-    user: userEvent.setup(),
+    get user() {
+      user ??= userEvent.setup();
+      return user;
+    },
     ...render(
       <MemoryRouterProvider {...routerOptions}>
         <NuqsTestingAdapter {...nuqsOptions}>{ui}</NuqsTestingAdapter>

--- a/apps/web/testing/setup-page.ts
+++ b/apps/web/testing/setup-page.ts
@@ -1,7 +1,4 @@
 import '@testing-library/jest-dom/vitest';
-import { getAllCategories } from '@cocktails/data/categories';
-import { getAllIngredients } from '@cocktails/data/ingredients';
-import { getAllRecipes } from '@cocktails/data/recipes';
 import { Storage } from 'happy-dom';
 import { vi } from 'vitest';
 
@@ -14,8 +11,3 @@ vi.mock('lite-youtube-embed', () => ({}));
 if (typeof localStorage?.clear !== 'function') {
   vi.stubGlobal('localStorage', new Storage());
 }
-
-// Pre-load and memoize data to speed up tests
-await getAllRecipes();
-await getAllCategories();
-await getAllIngredients();


### PR DESCRIPTION
## Summary

- speed up page-oriented Vitest coverage by replacing full-corpus page setup with small, inline real-data fixtures
- call `getRecipe`, `getIngredient`, and `getCategory` directly in tests for the specific JSON records each page scenario needs
- keep page tests readable and grounded in actual project data while avoiding repeated `getAll*` traversal of the full dataset

## Why

The slow page tests were paying for global recipe/category/ingredient preload and then rendering/searching large DOMs for repeated interaction cases. The new approach keeps realistic coverage through real JSON records, but narrows each page test to the records needed for that behavior.

Measured locally:

- before: full `yarn vitest --run` around 24.6s
- after: full `corepack yarn vitest --run --reporter=default` around 4.5-5.8s

## Validation

- `corepack yarn vitest --run --project page --reporter=default`
- `corepack yarn vitest --run --reporter=default`
- `corepack yarn lint`
- push hook: formatting, coverage test run, and `check-data`
