### PR TITLE
Fix recently added recipe ordering

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js ⚙️ - Cache dependencies ⚡ - Install dependencies 🔧
         uses: ./.github/workflows/setup-node

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js ⚙️ - Cache dependencies ⚡ - Install dependencies 🔧
         uses: ./.github/workflows/setup-node

--- a/packages/data/src/modules/recipes.test.ts
+++ b/packages/data/src/modules/recipes.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const execFileMocks = vi.hoisted(() => {
+  const promise = vi.fn();
+  const callback = Object.assign(vi.fn(), {
+    [Symbol.for('nodejs.util.promisify.custom')]: promise,
+  });
+  return { callback, promise };
+});
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMocks.callback,
+}));
+
+describe('getRecentlyAddedRecipes', () => {
+  it('orders recipes by git file-add date instead of recipe name', async () => {
+    const repoRoot = process.cwd();
+    const gitLog = [
+      'COMMIT 2026-05-16T13:10:12-04:00',
+      'packages/data/data/recipes/youtube-channel/educated-barfly/9th-wonder.json',
+      'COMMIT 2026-05-18T09:00:00-04:00',
+      'packages/data/data/recipes/youtube-channel/educated-barfly/snake-eyes.json',
+      'packages/data/data/recipes/youtube-channel/anders-erickson/belmont-jewel.json',
+    ].join('\n');
+
+    execFileMocks.promise.mockImplementation((command, args, options) => {
+      if (args.includes('rev-parse')) {
+        return Promise.resolve({ stdout: `${repoRoot}\n`, stderr: '' });
+      }
+
+      expect(command).toBe('git');
+      expect(options).toEqual({ cwd: repoRoot });
+      expect(args).toContain('--diff-filter=A');
+      return Promise.resolve({ stdout: gitLog, stderr: '' });
+    });
+
+    const { getRecentlyAddedRecipes } = await import('./recipes');
+    const recipes = await getRecentlyAddedRecipes();
+
+    expect(recipes.map((recipe) => recipe.name)).toEqual([
+      'Snake Eyes',
+      'Belmont Jewel',
+      '9th Wonder',
+    ]);
+  });
+});

--- a/packages/data/src/modules/recipes.ts
+++ b/packages/data/src/modules/recipes.ts
@@ -187,8 +187,7 @@ export const getRecentlyAddedRecipes = memo(async (): Promise<Recipe[]> => {
   const repoRoot = repoRootRaw.trim();
   const recipeRelPath = path.relative(repoRoot, RECIPE_ROOT);
 
-  // --diff-filter=A: only commits that first introduced each file (immune to bulk edits)
-  // git log is newest-first, so the first occurrence of each path is its most recent add
+  // --diff-filter=A: only commits that first introduced each file.
   const { stdout: gitLog } = await execFile(
     'git',
     [
@@ -197,7 +196,7 @@ export const getRecentlyAddedRecipes = memo(async (): Promise<Recipe[]> => {
       'log',
       '--diff-filter=A',
       '--name-only',
-      '--format=COMMIT %ai',
+      '--format=COMMIT %cI',
       '--',
       recipeRelPath,
     ],
@@ -210,12 +209,12 @@ export const getRecentlyAddedRecipes = memo(async (): Promise<Recipe[]> => {
     sourceSlug: string;
     recipeSlug: string;
     chapter?: string;
+    date: Date;
   }> = [];
 
   let currentDate: Date | null = null;
 
   for (const raw of gitLog.split('\n')) {
-    if (recent.length >= 30) break;
     const line = raw.trim();
     if (!line) continue;
 
@@ -237,6 +236,7 @@ export const getRecentlyAddedRecipes = memo(async (): Promise<Recipe[]> => {
             sourceType: sourceType as Source['type'],
             sourceSlug,
             recipeSlug: path.basename(filename, '.json'),
+            date: currentDate,
           };
         }
       } else if (parts.length === 4) {
@@ -248,6 +248,7 @@ export const getRecentlyAddedRecipes = memo(async (): Promise<Recipe[]> => {
             sourceSlug,
             recipeSlug: path.basename(filename, '.json'),
             chapter,
+            date: currentDate,
           };
         }
       }
@@ -263,9 +264,12 @@ export const getRecentlyAddedRecipes = memo(async (): Promise<Recipe[]> => {
   }
 
   return Promise.all(
-    recent.map(({ sourceType, sourceSlug, recipeSlug, chapter }) =>
-      getRecipe({ type: sourceType, slug: sourceSlug }, recipeSlug, chapter),
-    ),
+    recent
+      .toSorted((a, b) => b.date.getTime() - a.date.getTime())
+      .slice(0, 30)
+      .map(({ sourceType, sourceSlug, recipeSlug, chapter }) =>
+        getRecipe({ type: sourceType, slug: sourceSlug }, recipeSlug, chapter),
+      ),
   );
 });
 


### PR DESCRIPTION
## Summary

Fixes the Recently Added recipe list so it is ordered by the git date when recipe files were added, instead of inheriting the alphabetical path order returned inside each git log commit.

The list still only considers recipe files introduced by git add commits via `--diff-filter=A`; recipe file modifications are intentionally ignored.

Also updates the preview and production deploy workflows to fetch full git history before building the static site. The static export computes the Recently Added page at build time, so shallow checkouts cannot reliably answer when recipe files were added.

## Root cause

There were two issues:

1. `git log --name-only` returns paths alphabetically within a commit. The existing implementation stopped after collecting 30 entries and returned that path order directly, so batches of newly added recipes could appear alpha-sorted rather than date-ordered.
2. GitHub Actions checked out preview/deploy builds with `fetch-depth: 1`, so the exported page did not have enough git history to include recipes added by prior commits such as #274.

## Validation

- Verified locally at `/cocktails/list/recently-added` that PR #274 additions render at the top: Enzoni, Day-O Old Fashioned, Green Pepper, etc.
- `corepack yarn vitest --run packages/data/src/modules/recipes.test.ts`
- `corepack yarn lint`
- `corepack yarn vitest --run`
- `corepack yarn check-data`