### PR TITLE
Show book chapter on recipe pages

### DIFF
--- a/apps/web/app/recipes/[type]/[source]/[recipe]/page.test.tsx
+++ b/apps/web/app/recipes/[type]/[source]/[recipe]/page.test.tsx
@@ -1,0 +1,26 @@
+import { getRecipe } from '@cocktails/data/recipes';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { setupApp } from '#/testing';
+import RecipePage from './page';
+
+describe('RecipePage', () => {
+  it('renders book chapter beside the page number when available', async () => {
+    const bookRecipe = await getRecipe(
+      { type: 'book', slug: 'smugglers-cove' },
+      'jungle-bird',
+    );
+
+    setupApp(
+      await RecipePage({
+        params: Promise.resolve({
+          type: bookRecipe.source.type,
+          source: bookRecipe.source.slug,
+          recipe: bookRecipe.slug,
+        }),
+      }),
+    );
+
+    expect(screen.getByText('The Tiki Revival · page 96')).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/recipes/[type]/[source]/[recipe]/page.tsx
+++ b/apps/web/app/recipes/[type]/[source]/[recipe]/page.tsx
@@ -84,7 +84,12 @@ export default async function RecipePage({ params }: { params: Promise<Params> }
             </Paper>
           </List>
         )}
-        <SourceAboutCard source={recipe.source} refs={recipe.refs} sx={{ m: 1 }} />
+        <SourceAboutCard
+          source={recipe.source}
+          chapterName={recipe.chapter?.name}
+          refs={recipe.refs}
+          sx={{ m: 1 }}
+        />
         {recipe.attributions.length > 0 && (
           <RecipeAttributionCard recipe={recipe} sx={{ m: 1 }} />
         )}

--- a/apps/web/components/SourceAboutCard/Book.tsx
+++ b/apps/web/components/SourceAboutCard/Book.tsx
@@ -13,13 +13,19 @@ import {
 
 export default function BookAboutCard({
   source,
+  chapterName,
   page,
   sx,
 }: {
   source: Book;
+  chapterName?: string;
   page?: number;
   sx?: SxProps;
 }) {
+  const subheader = [chapterName, typeof page === 'number' ? `page ${page}` : undefined]
+    .filter(Boolean)
+    .join(' · ');
+
   return (
     <Card sx={sx}>
       <CardHeader
@@ -29,7 +35,7 @@ export default function BookAboutCard({
             &nbsp;{source.name}
           </>
         }
-        subheader={page ? `page ${page}` : undefined}
+        subheader={subheader || undefined}
       />
       <CardContent>
         <Typography variant="body2" sx={{ color: 'text.secondary' }}>

--- a/apps/web/components/SourceAboutCard/index.tsx
+++ b/apps/web/components/SourceAboutCard/index.tsx
@@ -10,10 +10,12 @@ const EMPTY_REFS: Ref[] = [];
 
 export default function SourceAboutCard({
   source,
+  chapterName,
   refs = EMPTY_REFS,
   sx,
 }: {
   source: Source;
+  chapterName?: string;
   refs?: Ref[];
   sx?: SxProps;
 }) {
@@ -23,7 +25,14 @@ export default function SourceAboutCard({
         (ref): ref is BookRef =>
           ref.type === 'book' && slugify(ref.title) === source.slug,
       );
-      return <BookAboutCard source={source} page={ref?.page} sx={sx} />;
+      return (
+        <BookAboutCard
+          source={source}
+          chapterName={chapterName}
+          page={ref?.page}
+          sx={sx}
+        />
+      );
     })
     .with({ type: 'youtube-channel' }, (source) => {
       const ref = refs.find((ref): ref is YoutubeRef => ref.type === 'youtube');


### PR DESCRIPTION
## Summary

- Show a book recipe chapter in the source card when chapter metadata is available.
- Keep the existing page-number display and source-card behavior for non-recipe contexts.
- Add a recipe page regression test for a chaptered book recipe.

## Validation

- corepack yarn lint
- corepack yarn vitest --run
- Push hook: lint, vitest --run --coverage, check-data
