### PR TITLE
Force dark mode

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -7,6 +7,7 @@ body {
 
 html {
   height: 100%;
+  color-scheme: dark;
 }
 
 body {
@@ -24,12 +25,6 @@ body {
 a {
   color: inherit;
   text-decoration: none;
-}
-
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
 }
 
 svg {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -42,7 +42,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" data-prefers-color-scheme="dark">
+    <html lang="en" data-prefers-color-scheme="dark" style={{ colorScheme: 'dark' }}>
       <head>
         <link
           rel="sitemap"
@@ -53,7 +53,7 @@ export default function RootLayout({
       </head>
       <body className={roboto.variable}>
         <AppRouterCacheProvider>
-          <ThemeProvider theme={theme}>
+          <ThemeProvider theme={theme} defaultMode="dark" storageManager={null}>
             <CssBaseline />
             <NuqsAdapter>
               <Box

--- a/apps/web/app/manifest.webmanifest/route.ts
+++ b/apps/web/app/manifest.webmanifest/route.ts
@@ -8,6 +8,8 @@ export function GET() {
     short_name: 'Cocktail Index',
     display: 'standalone',
     orientation: 'portrait',
+    background_color: '#0A1420',
+    theme_color: '#0A1420',
   };
 
   return Response.json(manifest);

--- a/apps/web/app/theme.tsx
+++ b/apps/web/app/theme.tsx
@@ -15,6 +15,7 @@ const LinkBehaviour = forwardRef(function LinkBehaviour(
 // Tiki nighttime palette inspired by tropical night scene
 const theme = createTheme({
   cssVariables: true,
+  defaultColorScheme: 'dark',
   typography: {
     fontFamily: 'var(--font-roboto)',
   },


### PR DESCRIPTION
## Summary

- Force MUI CSS variables to use the dark color scheme by default.
- Disable persisted MUI theme mode storage so stale light-mode choices cannot override dark mode.
- Set document and web manifest color-scheme metadata to dark.

## Why

The app only defines and designs for the nighttime palette. Relying on system preference or stored mode state can let browser UI and MUI state drift toward light mode, so this makes dark mode the only rendered mode.

## Validation

- `corepack yarn lint`
- `corepack yarn vitest --run`
