### PR TITLE
Improve unit test behavior coverage

### DIFF
--- a/apps/web/components/SearchInput/SearchInput.test.tsx
+++ b/apps/web/components/SearchInput/SearchInput.test.tsx
@@ -1,6 +1,18 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
 import SearchInput from './index';
+
+function StatefulSearchInput({ initialValue = '' }: { initialValue?: string }) {
+  const [value, setValue] = useState(initialValue);
+
+  return (
+    <SearchInput
+      value={value}
+      onChangeAction={(nextValue) => setValue(nextValue ?? '')}
+    />
+  );
+}
 
 describe('SearchInput', () => {
   it('renders with placeholder text', () => {
@@ -25,16 +37,14 @@ describe('SearchInput', () => {
     expect(input).toHaveAttribute('placeholder', 'Search…');
   });
 
-  it('calls onChangeAction when user types', async () => {
+  it('updates the visible value when user types', async () => {
     const user = userEvent.setup();
-    const onChangeAction = vi.fn();
-    render(<SearchInput value="" onChangeAction={onChangeAction} />);
+    render(<StatefulSearchInput />);
 
     const input = screen.getByRole('searchbox');
     await user.type(input, 'margarita');
 
-    expect(onChangeAction).toHaveBeenCalledTimes('margarita'.length);
-    expect(onChangeAction).toHaveBeenLastCalledWith('a');
+    expect(input).toHaveValue('margarita');
   });
 
   it('clears value and calls onChangeAction with null when clear button clicked', async () => {

--- a/apps/web/components/ServingSelector/ServingSelector.test.tsx
+++ b/apps/web/components/ServingSelector/ServingSelector.test.tsx
@@ -1,5 +1,13 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
 import ServingSelector from './index';
+
+function StatefulServingSelector({ initialServings = 2 }: { initialServings?: number }) {
+  const [servings, setServings] = useState(initialServings);
+
+  return <ServingSelector servings={servings} onChange={setServings} />;
+}
 
 describe('ServingSelector', () => {
   it('should render with current servings value and call onChange', () => {
@@ -24,6 +32,9 @@ describe('ServingSelector', () => {
     fireEvent.change(input, { target: { value: '-1' } });
     expect(onChange).not.toHaveBeenCalled();
 
+    fireEvent.change(input, { target: { value: '0.1' } });
+    expect(onChange).not.toHaveBeenCalled();
+
     // Should not call onChange for invalid values above maximum
     fireEvent.change(input, { target: { value: '51' } });
     expect(onChange).not.toHaveBeenCalled();
@@ -39,8 +50,9 @@ describe('ServingSelector', () => {
     render(<ServingSelector servings={2} onChange={onChange} />);
 
     const input = screen.getByLabelText('Number of servings');
-    expect(input).toHaveAttribute('min', '0');
+    expect(input).toHaveAttribute('min', '0.25');
     expect(input).toHaveAttribute('max', '50');
+    expect(input).toHaveAttribute('step', '0.25');
     expect(input).toHaveAttribute('type', 'number');
   });
 
@@ -145,29 +157,29 @@ describe('ServingSelector', () => {
   });
 
   describe('Input blur behavior', () => {
-    it('should reset to current value when invalid input is entered and field loses focus', () => {
-      const onChange = vi.fn();
-      render(<ServingSelector servings={2} onChange={onChange} />);
+    it('should reset to current value when invalid input is entered and field loses focus', async () => {
+      const user = userEvent.setup();
+      render(<StatefulServingSelector />);
 
       const input = screen.getByLabelText('Number of servings');
 
-      // Enter invalid value
-      fireEvent.change(input, { target: { value: '0.1' } });
-      fireEvent.blur(input);
+      await user.clear(input);
+      await user.paste('0.1');
+      await user.tab();
 
       // Should reset to current servings value
       expect(input).toHaveValue(2);
     });
 
-    it('should reset to current value when value above maximum is entered and field loses focus', () => {
-      const onChange = vi.fn();
-      render(<ServingSelector servings={2} onChange={onChange} />);
+    it('should reset to current value when value above maximum is entered and field loses focus', async () => {
+      const user = userEvent.setup();
+      render(<StatefulServingSelector />);
 
       const input = screen.getByLabelText('Number of servings');
 
-      // Enter invalid value
-      fireEvent.change(input, { target: { value: '100' } });
-      fireEvent.blur(input);
+      await user.clear(input);
+      await user.paste('100');
+      await user.tab();
 
       // Should reset to current servings value
       expect(input).toHaveValue(2);

--- a/apps/web/components/ServingSelector/index.tsx
+++ b/apps/web/components/ServingSelector/index.tsx
@@ -5,6 +5,9 @@ import { TextField, IconButton, InputAdornment } from '@mui/material';
 import type { ChangeEvent } from 'react';
 import { useState, useEffect } from 'react';
 
+const MIN_SERVINGS = 0.25;
+const MAX_SERVINGS = 50;
+
 export default function ServingSelector({
   servings,
   onChange,
@@ -28,7 +31,7 @@ export default function ServingSelector({
     // Only trigger onChange if the value is valid
     if (newInputValue !== '') {
       const value = parseFloat(newInputValue);
-      if (!isNaN(value) && value > 0 && value <= 50) {
+      if (!isNaN(value) && value >= MIN_SERVINGS && value <= MAX_SERVINGS) {
         onChange(value);
         setInputValue(undefined);
       }
@@ -38,7 +41,7 @@ export default function ServingSelector({
   const handleIncrement = () => {
     setInputValue(undefined);
 
-    if (servings < 50) {
+    if (servings < MAX_SERVINGS) {
       if (servings < 1) {
         // From fractional values, go to 1
         onChange(1);
@@ -53,13 +56,13 @@ export default function ServingSelector({
     setInputValue(undefined);
 
     // At 0.25, button will be disabled
-    if (servings > 0.25) {
+    if (servings > MIN_SERVINGS) {
       if (servings > 1) {
         onChange(servings - 1);
       } else if (servings > 0.5) {
         onChange(0.5);
       } else {
-        onChange(0.25);
+        onChange(MIN_SERVINGS);
       }
     }
   };
@@ -82,7 +85,7 @@ export default function ServingSelector({
             <InputAdornment position="start">
               <IconButton
                 onClick={handleDecrement}
-                disabled={servings <= 0.25}
+                disabled={servings <= MIN_SERVINGS}
                 size="small"
                 aria-label="Decrement"
               >
@@ -94,7 +97,7 @@ export default function ServingSelector({
             <InputAdornment position="end">
               <IconButton
                 onClick={handleIncrement}
-                disabled={servings >= 50}
+                disabled={servings >= MAX_SERVINGS}
                 size="small"
                 aria-label="Increment"
               >
@@ -104,9 +107,9 @@ export default function ServingSelector({
           ),
         },
         htmlInput: {
-          min: 0,
-          max: 50,
-          step: 1,
+          min: MIN_SERVINGS,
+          max: MAX_SERVINGS,
+          step: MIN_SERVINGS,
           'aria-label': 'Number of servings',
         },
       }}

--- a/apps/web/modules/searchText.test.ts
+++ b/apps/web/modules/searchText.test.ts
@@ -63,7 +63,7 @@ describe('getRecipeSearchText', () => {
       ],
     });
     expect(getRecipeSearchText(recipe)).toMatchInlineSnapshot(
-      `"test recipe white rum  lime juice"`,
+      `"test recipe white rum lime juice"`,
     );
   });
 
@@ -89,7 +89,7 @@ describe('getRecipeSearchText', () => {
       ],
     });
     expect(getRecipeSearchText(recipe)).toMatchInlineSnapshot(
-      `"test recipe  smuggler's cove martin cate"`,
+      `"test recipe smuggler's cove martin cate"`,
     );
   });
 

--- a/apps/web/modules/searchText.ts
+++ b/apps/web/modules/searchText.ts
@@ -12,7 +12,7 @@ import { formatIngredientName } from './technique.ts';
  * Returns transliterated lowercase text suitable for fuzzy search matching.
  */
 function normalize(text: string): string {
-  return transliterate(text).toLowerCase().trim();
+  return transliterate(text).toLowerCase().replace(/\s+/g, ' ').trim();
 }
 
 /**

--- a/packages/ingredient-sorting/src/ingredientSorting.test.ts
+++ b/packages/ingredient-sorting/src/ingredientSorting.test.ts
@@ -127,7 +127,7 @@ describe('compareIngredients', () => {
       );
     });
 
-    it('should sort top after rinse but before float', () => {
+    it('should sort top after float', () => {
       const result = [
         createTestIngredient({
           type: 'bitter',


### PR DESCRIPTION
## Summary

- Enforce the serving selector minimum consistently at 0.25 servings.
- Update component tests to assert observable controlled input behavior instead of callback artifacts.
- Normalize search text whitespace and clean up a misleading ingredient sorting test name.

## Testing

- corepack yarn vitest --run apps/web/components/ServingSelector/ServingSelector.test.tsx apps/web/components/SearchInput/SearchInput.test.tsx apps/web/modules/searchText.test.ts packages/ingredient-sorting/src/ingredientSorting.test.ts
- corepack yarn vitest --run
- corepack yarn lint
- pre-push hook reran formatting, full tests with coverage, and check-data