### PR TITLE
Model whole-cocktail milk clarification

### DIFF
--- a/apps/web/app/recipes/[type]/[source]/[recipe]/page.test.tsx
+++ b/apps/web/app/recipes/[type]/[source]/[recipe]/page.test.tsx
@@ -1,5 +1,5 @@
 import { getRecipe } from '@cocktails/data/recipes';
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { setupApp } from '#/vitest.setup';
 import RecipePage from './page';
@@ -22,5 +22,39 @@ describe('RecipePage', () => {
     );
 
     expect(screen.getByText('The Tiki Revival · page 96')).toBeInTheDocument();
+  });
+
+  it('renders whole-recipe clarification in a scalable technique section', async () => {
+    const clarifiedRecipe = await getRecipe(
+      { type: 'youtube-channel', slug: 'truffles-on-the-rocks' },
+      'clarified-new-york-sour',
+    );
+
+    const { user } = setupApp(
+      await RecipePage({
+        params: Promise.resolve({
+          type: clarifiedRecipe.source.type,
+          source: clarifiedRecipe.source.slug,
+          recipe: clarifiedRecipe.slug,
+        }),
+      }),
+    );
+
+    const recipeContent = screen.getByRole('main');
+    expect(recipeContent).toHaveTextContent('stirred');
+    expect(screen.queryByText('Whole milk clarified')).not.toBeInTheDocument();
+
+    const technique = screen.getByRole('list', { name: 'Milk clarification' });
+    const techniqueDetails = within(technique).getByRole('listitem');
+    expect(techniqueDetails).not.toHaveTextContent('Milk clarification');
+    expect(techniqueDetails).toHaveTextContent('5ozWhole milk');
+
+    await user.click(screen.getByRole('button', { name: 'ml' }));
+
+    expect(techniqueDetails).toHaveTextContent('150mlWhole milk');
+
+    await user.click(screen.getByRole('button', { name: 'Increment' }));
+
+    expect(techniqueDetails).toHaveTextContent('300mlWhole milk');
   });
 });

--- a/apps/web/app/recipes/[type]/[source]/[recipe]/page.tsx
+++ b/apps/web/app/recipes/[type]/[source]/[recipe]/page.tsx
@@ -68,6 +68,7 @@ export default async function RecipePage({ params }: { params: Promise<Params> }
         </Grid>
         <IngredientList
           ingredients={recipe.ingredients}
+          techniques={recipe.techniques}
           defaultServings={recipe.servings}
         />
         {Array.isArray(recipe.instructions) && recipe.instructions.length > 0 && (

--- a/apps/web/components/IngredientList/index.tsx
+++ b/apps/web/components/IngredientList/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { Recipe } from '@cocktails/data';
+import type { Recipe, RecipeTechnique } from '@cocktails/data';
 import { compareIngredients } from '@cocktails/ingredient-sorting';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import {
@@ -13,15 +13,18 @@ import {
   Toolbar,
 } from '@mui/material';
 import Link from 'next/link';
-import { useMemo, useState } from 'react';
+import { Fragment, useMemo, useState } from 'react';
+import { match } from 'ts-pattern';
 import Quantity from '#/components/Quantity';
 import UnitSelector, { type Unit } from '#/components/Quantity/Selector';
 import ServingSelector from '#/components/ServingSelector';
 import useLocalStorage from '#/hooks/useLocalStorage';
 import { calculateScaleFactor, scaleQuantity } from '#/modules/scaling';
-import { formatIngredientName } from '#/modules/technique';
+import { formatIngredientName, formatRecipeTechniqueName } from '#/modules/technique';
 import { getRecipeIngredientUrl } from '#/modules/url';
 import styles from './style.module.css';
+
+const EMPTY_TECHNIQUES: RecipeTechnique[] = [];
 
 function IngredientLine({
   ingredient,
@@ -57,28 +60,55 @@ function IngredientLine({
   );
 }
 
+function TechniqueDetails({
+  technique,
+  preferredUnit,
+}: {
+  technique: RecipeTechnique;
+  preferredUnit: Unit;
+}) {
+  return match(technique)
+    .with({ technique: 'clarification', method: 'milk' }, (milkClarification) => (
+      <Stack direction="row" spacing={0.5} sx={{ alignItems: 'baseline' }}>
+        <Quantity preferredUnit={preferredUnit} quantity={milkClarification.quantity} />
+        <div className={styles.name}>{milkClarification.milk_type}</div>
+      </Stack>
+    ))
+    .exhaustive();
+}
+
 export default function IngredientList({
   ingredients,
+  techniques = EMPTY_TECHNIQUES,
   defaultServings = 1,
 }: {
   ingredients: Recipe['ingredients'];
+  techniques?: RecipeTechnique[];
   defaultServings?: number;
 }) {
   const [preferredUnit, setPreferredUnit] = useLocalStorage<Unit>('preferred_unit', 'oz');
   const [servings, setServings] = useState(defaultServings);
   const scaleFactor = calculateScaleFactor(defaultServings, servings);
 
-  // Scale all ingredients at the list level
   const scaledIngredients = useMemo(
     () =>
-      ingredients.map((ingredient) => ({
-        ...ingredient,
-        quantity:
-          scaleFactor !== 1
-            ? scaleQuantity(ingredient.quantity, scaleFactor)
-            : ingredient.quantity,
-      })),
+      scaleFactor === 1
+        ? ingredients
+        : ingredients.map((ingredient) => ({
+            ...ingredient,
+            quantity: scaleQuantity(ingredient.quantity, scaleFactor),
+          })),
     [ingredients, scaleFactor],
+  );
+  const scaledTechniques = useMemo(
+    () =>
+      scaleFactor === 1
+        ? techniques
+        : techniques.map((recipeTechnique) => ({
+            ...recipeTechnique,
+            quantity: scaleQuantity(recipeTechnique.quantity, scaleFactor),
+          })),
+    [scaleFactor, techniques],
   );
 
   return (
@@ -102,6 +132,29 @@ export default function IngredientList({
           })}
         </Paper>
       </List>
+      {scaledTechniques.map((recipeTechnique) => {
+        const headingId = `recipe-technique-${recipeTechnique.technique}-heading`;
+
+        return (
+          <Fragment key={recipeTechnique.technique}>
+            <ListSubheader component="div" id={headingId}>
+              {formatRecipeTechniqueName(recipeTechnique)}
+            </ListSubheader>
+            <List aria-labelledby={headingId}>
+              <Paper square>
+                <ListItem divider>
+                  <ListItemText>
+                    <TechniqueDetails
+                      technique={recipeTechnique}
+                      preferredUnit={preferredUnit}
+                    />
+                  </ListItemText>
+                </ListItem>
+              </Paper>
+            </List>
+          </Fragment>
+        );
+      })}
       <Toolbar sx={{ justifyContent: 'space-between', px: 1 }}>
         <UnitSelector value={preferredUnit} onChange={setPreferredUnit} />
         <ServingSelector servings={servings} onChange={setServings} />

--- a/apps/web/modules/searchText.test.ts
+++ b/apps/web/modules/searchText.test.ts
@@ -93,6 +93,39 @@ describe('getRecipeSearchText', () => {
     );
   });
 
+  it('includes the canonical and formatted whole-recipe technique names', () => {
+    const recipe = createMockRecipe({
+      techniques: [
+        {
+          technique: 'clarification',
+          method: 'milk',
+          milk_type: 'Coconut milk',
+          quantity: { amount: 4, unit: 'oz' },
+        },
+      ],
+    });
+
+    expect(getRecipeSearchText(recipe)).toMatchInlineSnapshot(
+      `"test recipe clarification coconut milk clarified"`,
+    );
+  });
+
+  it('keeps ingredient clarification scoped to its ingredient', () => {
+    const recipe = createMockRecipe({
+      ingredients: [
+        createMockRecipeIngredient({
+          name: 'Lime juice',
+          type: 'juice',
+          technique: { technique: 'clarification', method: 'milk' },
+        }),
+      ],
+    });
+
+    expect(getRecipeSearchText(recipe)).toMatchInlineSnapshot(
+      `"test recipe milk-clarified lime juice"`,
+    );
+  });
+
   it('transliterates special characters', () => {
     const recipe = createMockRecipe({ name: 'Café Cubano' });
     expect(getRecipeSearchText(recipe)).toMatchInlineSnapshot(`"cafe cubano"`);

--- a/apps/web/modules/searchText.ts
+++ b/apps/web/modules/searchText.ts
@@ -6,7 +6,7 @@ import type {
   RecipeIngredient,
 } from '@cocktails/data';
 import transliterate from '@sindresorhus/transliterate';
-import { formatIngredientName } from './technique.ts';
+import { formatIngredientName, formatRecipeTechnique } from './technique.ts';
 
 /**
  * Returns transliterated lowercase text suitable for fuzzy search matching.
@@ -42,9 +42,13 @@ function getAttributionSearchText(attribution: Attribution): string {
 export function getRecipeSearchText(recipe: Recipe): string {
   const ingredientParts = recipe.ingredients.map(getIngredientSearchText);
   const attributionParts = recipe.attributions.map(getAttributionSearchText);
+  const techniqueParts =
+    recipe.techniques?.map(
+      (technique) => `${technique.technique} ${formatRecipeTechnique(technique)}`,
+    ) ?? [];
 
   return normalize(
-    `${recipe.name} ${ingredientParts.join(' ')} ${attributionParts.join(' ')}`,
+    `${recipe.name} ${techniqueParts.join(' ')} ${ingredientParts.join(' ')} ${attributionParts.join(' ')}`,
   );
 }
 

--- a/apps/web/modules/technique.test.ts
+++ b/apps/web/modules/technique.test.ts
@@ -1,6 +1,6 @@
 import type { RecipeIngredient } from '@cocktails/data';
 import { describe, it, expect } from 'vitest';
-import { formatIngredientName } from './technique';
+import { formatIngredientName, formatRecipeTechniqueName } from './technique';
 
 // Helper to create a basic ingredient for testing
 function createIngredient(overrides: Partial<RecipeIngredient> = {}): RecipeIngredient {
@@ -386,5 +386,18 @@ describe('formatIngredientName', () => {
       });
       expect(formatIngredientName(ingredient)).toBe('cucumber slice');
     });
+  });
+});
+
+describe('formatRecipeTechniqueName', () => {
+  it('formats milk clarification as a recipe technique name', () => {
+    expect(
+      formatRecipeTechniqueName({
+        technique: 'clarification',
+        method: 'milk',
+        milk_type: 'Whole milk',
+        quantity: { amount: 5, unit: 'oz' },
+      }),
+    ).toBe('Milk clarification');
   });
 });

--- a/apps/web/modules/technique.ts
+++ b/apps/web/modules/technique.ts
@@ -1,4 +1,4 @@
-import type { RecipeIngredient, Technique } from '@cocktails/data';
+import type { RecipeIngredient, RecipeTechnique, Technique } from '@cocktails/data';
 import { match } from 'ts-pattern';
 
 const cutTypeNames = {
@@ -78,4 +78,19 @@ export function formatIngredientName(ingredient: RecipeIngredient): string {
 
   // Handle single technique (backward compatibility)
   return formatSingleTechnique(ingredient.technique, name, ingredient);
+}
+
+export function formatRecipeTechnique(technique: RecipeTechnique): string {
+  return match(technique)
+    .with(
+      { technique: 'clarification', method: 'milk' },
+      ({ milk_type: milkType }) => `${milkType} clarified`,
+    )
+    .exhaustive();
+}
+
+export function formatRecipeTechniqueName(technique: RecipeTechnique): string {
+  return match(technique)
+    .with({ technique: 'clarification', method: 'milk' }, () => 'Milk clarification')
+    .exhaustive();
 }

--- a/packages/check-data/src/check-data.ts
+++ b/packages/check-data/src/check-data.ts
@@ -12,6 +12,10 @@ import Ajv from 'ajv/dist/2020.js';
 import { format as formatWithOxfmt } from 'oxfmt';
 import { logger } from './cli-util.ts';
 import { findFloatingIngredients } from './floating-ingredients.ts';
+import {
+  getMilkClarificationIngredientSlugs,
+  validateMilkClarification,
+} from './milk-clarification.ts';
 import { areSimilarNames } from './name-similarity.ts';
 
 const startTime = performance.now();
@@ -41,6 +45,12 @@ interface DataWithSchema {
   attributions?: Attribution[];
   categories?: string[];
   parents?: string[];
+  techniques?: Array<{
+    technique: 'clarification';
+    method: 'milk';
+    milk_type: string;
+    quantity: { amount: number; unit: string };
+  }>;
 }
 
 function addCategoryType(
@@ -252,6 +262,19 @@ for await (const sourceFile of fs.glob(dataGlob)) {
 
   // Collect bar attributions for case consistency check
   if (schemaPath === 'schemas/recipe.schema.json') {
+    if (isValid) {
+      for (const message of validateMilkClarification(
+        { ingredients: data.ingredients ?? [], techniques: data.techniques },
+        canonicalNames,
+        ingredientFolders,
+      )) {
+        fail(`${message} in ${path.basename(sourceFile)}`);
+      }
+      for (const ingredientSlug of getMilkClarificationIngredientSlugs(data)) {
+        referencedIngredientSlugs.add(ingredientSlug);
+      }
+    }
+
     for (const attribution of data.attributions ?? []) {
       if (attribution.relation === 'bar') {
         const lowerName = attribution.source.toLowerCase();

--- a/packages/check-data/src/milk-clarification.test.ts
+++ b/packages/check-data/src/milk-clarification.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getMilkClarificationIngredientSlugs,
+  validateMilkClarification,
+} from './milk-clarification.ts';
+
+const canonicalIngredientNames = new Map([
+  ['whole-milk', 'Whole milk'],
+  ['coconut-milk', 'Coconut milk'],
+]);
+const ingredientFolders = new Map([
+  ['whole-milk', 'other'],
+  ['coconut-milk', 'other'],
+]);
+
+describe('validateMilkClarification', () => {
+  it('accepts a canonical milk type stored with the recipe technique', () => {
+    expect(
+      validateMilkClarification(
+        {
+          ingredients: [],
+          techniques: [
+            {
+              technique: 'clarification',
+              method: 'milk',
+              milk_type: 'Coconut milk',
+              quantity: { amount: 4, unit: 'oz' },
+            },
+          ],
+        },
+        canonicalIngredientNames,
+        ingredientFolders,
+      ),
+    ).toEqual([]);
+  });
+
+  it('requires the canonical ingredient name', () => {
+    expect(
+      validateMilkClarification(
+        {
+          ingredients: [],
+          techniques: [
+            {
+              technique: 'clarification',
+              method: 'milk',
+              milk_type: 'whole milk',
+              quantity: { amount: 4, unit: 'oz' },
+            },
+          ],
+        },
+        canonicalIngredientNames,
+        ingredientFolders,
+      ),
+    ).toEqual(['Milk type "whole milk" must use canonical ingredient name "Whole milk"']);
+  });
+
+  it('requires the milk type to name a canonical ingredient', () => {
+    expect(
+      validateMilkClarification(
+        {
+          ingredients: [],
+          techniques: [
+            {
+              technique: 'clarification',
+              method: 'milk',
+              milk_type: 'Oat milk',
+              quantity: { amount: 4, unit: 'oz' },
+            },
+          ],
+        },
+        canonicalIngredientNames,
+        ingredientFolders,
+      ),
+    ).toEqual(['Milk type "Oat milk" is not a canonical ingredient']);
+  });
+
+  it('rejects milk duplicated in the recipe ingredients', () => {
+    expect(
+      validateMilkClarification(
+        {
+          ingredients: [{ name: 'Whole milk' }],
+          techniques: [
+            {
+              technique: 'clarification',
+              method: 'milk',
+              milk_type: 'Whole milk',
+              quantity: { amount: 4, unit: 'oz' },
+            },
+          ],
+        },
+        canonicalIngredientNames,
+        ingredientFolders,
+      ),
+    ).toEqual([
+      'Milk type "Whole milk" must be defined only by the recipe technique, not listed as a recipe ingredient',
+    ]);
+  });
+
+  it('validates every technique in an ordered sequence', () => {
+    expect(
+      validateMilkClarification(
+        {
+          ingredients: [],
+          techniques: [
+            {
+              technique: 'clarification',
+              method: 'milk',
+              milk_type: 'Whole milk',
+              quantity: { amount: 4, unit: 'oz' },
+            },
+            {
+              technique: 'clarification',
+              method: 'milk',
+              milk_type: 'coconut milk',
+              quantity: { amount: 4, unit: 'oz' },
+            },
+          ],
+        },
+        canonicalIngredientNames,
+        ingredientFolders,
+      ),
+    ).toEqual([
+      'Milk type "coconut milk" must use canonical ingredient name "Coconut milk"',
+    ]);
+  });
+
+  it('collects technique milk types as ingredient references', () => {
+    expect(
+      getMilkClarificationIngredientSlugs({
+        techniques: [
+          {
+            technique: 'clarification',
+            method: 'milk',
+            milk_type: 'Whole milk',
+            quantity: { amount: 4, unit: 'oz' },
+          },
+          {
+            technique: 'clarification',
+            method: 'milk',
+            milk_type: 'Coconut milk',
+            quantity: { amount: 4, unit: 'oz' },
+          },
+        ],
+      }),
+    ).toEqual(['whole-milk', 'coconut-milk']);
+  });
+});

--- a/packages/check-data/src/milk-clarification.ts
+++ b/packages/check-data/src/milk-clarification.ts
@@ -1,0 +1,54 @@
+import slugify from '@sindresorhus/slugify';
+
+type MilkClarificationTechnique = {
+  technique: 'clarification';
+  method: 'milk';
+  milk_type: string;
+  quantity: { amount: number; unit: string };
+};
+
+function getTechniques(recipe: {
+  techniques?: MilkClarificationTechnique[];
+}): MilkClarificationTechnique[] {
+  return recipe.techniques ?? [];
+}
+
+export function getMilkClarificationIngredientSlugs(recipe: {
+  techniques?: MilkClarificationTechnique[];
+}): string[] {
+  return getTechniques(recipe).map((technique) => slugify(technique.milk_type));
+}
+
+export function validateMilkClarification(
+  recipe: {
+    ingredients: Array<{ name: string }>;
+    techniques?: MilkClarificationTechnique[];
+  },
+  canonicalNames: ReadonlyMap<string, string>,
+  ingredientFolders: ReadonlyMap<string, string>,
+): string[] {
+  return getTechniques(recipe).flatMap((technique) => {
+    const milkTypeSlug = slugify(technique.milk_type);
+    const canonicalName = canonicalNames.get(milkTypeSlug);
+
+    if (!canonicalName || !ingredientFolders.has(milkTypeSlug)) {
+      return [`Milk type "${technique.milk_type}" is not a canonical ingredient`];
+    }
+
+    if (canonicalName !== technique.milk_type) {
+      return [
+        `Milk type "${technique.milk_type}" must use canonical ingredient name "${canonicalName}"`,
+      ];
+    }
+
+    if (
+      recipe.ingredients.some((ingredient) => slugify(ingredient.name) === milkTypeSlug)
+    ) {
+      return [
+        `Milk type "${canonicalName}" must be defined only by the recipe technique, not listed as a recipe ingredient`,
+      ];
+    }
+
+    return [];
+  });
+}

--- a/packages/data/data/recipes/book/tiki-modern-tropical-cocktails/08_Communal Drinks/rios-del-miel.json
+++ b/packages/data/data/recipes/book/tiki-modern-tropical-cocktails/08_Communal Drinks/rios-del-miel.json
@@ -2,6 +2,17 @@
   "$schema": "../../../../../schemas/recipe.schema.json",
   "name": "Rios Del Miel",
   "preparation": "built",
+  "techniques": [
+    {
+      "technique": "clarification",
+      "method": "milk",
+      "milk_type": "Whole milk",
+      "quantity": {
+        "amount": 34,
+        "unit": "oz"
+      }
+    }
+  ],
   "served_on": "ice cubes",
   "glassware": "punch",
   "servings": 10,
@@ -84,14 +95,6 @@
       "quantity": {
         "amount": 2,
         "unit": "cup"
-      }
-    },
-    {
-      "name": "Whole milk",
-      "type": "other",
-      "quantity": {
-        "amount": 34,
-        "unit": "oz"
       }
     },
     {

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/after-eight.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/after-eight.json
@@ -2,6 +2,17 @@
   "$schema": "../../../../schemas/recipe.schema.json",
   "name": "After Eight",
   "preparation": "other",
+  "techniques": [
+    {
+      "technique": "clarification",
+      "method": "milk",
+      "milk_type": "Whole milk",
+      "quantity": {
+        "amount": 1,
+        "unit": "cup"
+      }
+    }
+  ],
   "served_on": "up",
   "glassware": "coupe",
   "servings": 10,
@@ -48,7 +59,7 @@
     }
   ],
   "instructions": [
-    "Combine all ingredients and pour over 1 cup (250ml) of whole milk mixed with 6–7 crushed Mint Oreo cookies.",
+    "Combine the cocktail ingredients and pour over the whole milk mixed with 6–7 crushed Mint Oreo cookies.",
     "Let sit for 5 minutes, then fine-strain through cheesecloth to clarify.",
     "Serve 2.5 oz (75ml) portions.",
     "Top each serving with mint foam: blend 400ml mint water with 0.8g xanthan gum and 12g methylcellulose F50, then add 1 oz crème de menthe, ½ oz simple syrup, and ½ oz lime juice. Aerate until foamy and spoon over the drink."

--- a/packages/data/data/recipes/youtube-channel/truffles-on-the-rocks/clarified-new-york-sour.json
+++ b/packages/data/data/recipes/youtube-channel/truffles-on-the-rocks/clarified-new-york-sour.json
@@ -2,6 +2,17 @@
   "$schema": "../../../../schemas/recipe.schema.json",
   "name": "Clarified New York Sour",
   "preparation": "stirred",
+  "techniques": [
+    {
+      "technique": "clarification",
+      "method": "milk",
+      "milk_type": "Whole milk",
+      "quantity": {
+        "amount": 5,
+        "unit": "oz"
+      }
+    }
+  ],
   "served_on": "big rock",
   "glassware": "old fashioned",
   "ingredients": [
@@ -16,14 +27,6 @@
     {
       "name": "Lemon juice",
       "type": "juice",
-      "quantity": {
-        "amount": 5,
-        "unit": "oz"
-      }
-    },
-    {
-      "name": "Whole milk",
-      "type": "other",
       "quantity": {
         "amount": 5,
         "unit": "oz"

--- a/packages/data/schemas/recipe-technique.schema.json
+++ b/packages/data/schemas/recipe-technique.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "./recipe-technique.schema.json",
+  "title": "Recipe technique",
+  "description": "A technique applied to a complete cocktail recipe",
+  "type": "object",
+  "properties": {
+    "technique": { "const": "clarification" },
+    "method": { "const": "milk" },
+    "milk_type": { "type": "string" },
+    "quantity": { "$ref": "./quantity.schema.json" }
+  },
+  "required": ["technique", "method", "milk_type", "quantity"],
+  "additionalProperties": false
+}

--- a/packages/data/schemas/recipe.schema.json
+++ b/packages/data/schemas/recipe.schema.json
@@ -18,6 +18,25 @@
         "other"
       ]
     },
+    "techniques": {
+      "type": "array",
+      "items": { "$ref": "./recipe-technique.schema.json" },
+      "minItems": 1,
+      "uniqueItems": true,
+      "allOf": [
+        {
+          "contains": {
+            "type": "object",
+            "properties": {
+              "technique": { "const": "clarification" }
+            },
+            "required": ["technique"]
+          },
+          "minContains": 0,
+          "maxContains": 1
+        }
+      ]
+    },
     "served_on": {
       "enum": ["big rock", "up", "crushed ice", "blended", "ice cubes"]
     },

--- a/packages/data/schemas/recipe.schema.test.ts
+++ b/packages/data/schemas/recipe.schema.test.ts
@@ -1,0 +1,97 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import Ajv from 'ajv/dist/2020.js';
+import { describe, expect, it } from 'vitest';
+
+async function getRecipeValidator() {
+  const ajv = new Ajv();
+  const schemasGlob = path.join(import.meta.dirname, '*.schema.json');
+
+  for await (const schemaFile of fs.glob(schemasGlob)) {
+    const schema = JSON.parse(await fs.readFile(schemaFile, 'utf-8'));
+    ajv.addSchema(schema, path.basename(schemaFile));
+  }
+
+  const validate = ajv.getSchema('recipe.schema.json');
+  if (!validate) {
+    throw new Error('Recipe schema not registered');
+  }
+
+  return validate;
+}
+
+describe('recipe schema', () => {
+  it('requires whole-recipe techniques to use the plural array field', async () => {
+    const validate = await getRecipeValidator();
+
+    expect(
+      validate({
+        name: 'Singular Clarification',
+        preparation: 'stirred',
+        technique: {
+          technique: 'clarification',
+          method: 'milk',
+          milk_type: 'Whole milk',
+          quantity: { amount: 4, unit: 'oz' },
+        },
+        served_on: 'up',
+        glassware: 'coupe',
+        ingredients: [
+          {
+            name: 'Lime juice',
+            type: 'juice',
+            quantity: { amount: 1, unit: 'oz' },
+          },
+        ],
+      }),
+    ).toBe(false);
+    expect(validate.errors).toContainEqual(
+      expect.objectContaining({
+        instancePath: '',
+        keyword: 'additionalProperties',
+        params: { additionalProperty: 'technique' },
+      }),
+    );
+  });
+
+  it('rejects duplicate recipe techniques', async () => {
+    const validate = await getRecipeValidator();
+
+    expect(
+      validate({
+        name: 'Duplicate Clarification',
+        preparation: 'stirred',
+        techniques: [
+          {
+            technique: 'clarification',
+            method: 'milk',
+            milk_type: 'Whole milk',
+            quantity: { amount: 4, unit: 'oz' },
+          },
+          {
+            technique: 'clarification',
+            method: 'milk',
+            milk_type: 'Coconut milk',
+            quantity: { amount: 2, unit: 'oz' },
+          },
+        ],
+        served_on: 'up',
+        glassware: 'coupe',
+        ingredients: [
+          {
+            name: 'Lime juice',
+            type: 'juice',
+            quantity: { amount: 1, unit: 'oz' },
+          },
+        ],
+      }),
+    ).toBe(false);
+    expect(validate.errors).toContainEqual(
+      expect.objectContaining({
+        instancePath: '/techniques',
+        keyword: 'contains',
+        params: expect.objectContaining({ maxContains: 1 }),
+      }),
+    );
+  });
+});

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -19,6 +19,6 @@ export type {
   RootIngredient,
   Technique,
 } from './types/Ingredient.ts';
-export type { Attribution, Chapter, Recipe } from './types/Recipe.ts';
+export type { Attribution, Chapter, Recipe, RecipeTechnique } from './types/Recipe.ts';
 export type { BookRef, PodcastRef, Ref, WebsiteRef, YoutubeRef } from './types/Ref.ts';
 export type { Book, Podcast, Source, YoutubeChannel } from './types/Source.ts';

--- a/packages/data/src/modules/ingredients.test.ts
+++ b/packages/data/src/modules/ingredients.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RootIngredient } from '../types/Ingredient.ts';
+import type { Recipe } from '../types/Recipe.ts';
+import type { Source } from '../types/Source.ts';
+import { getAllRecipes } from './recipes';
+
+vi.mock('./recipes', () => ({ getAllRecipes: vi.fn() }));
+
+const source = {
+  type: 'book',
+  name: 'Test Book',
+  slug: 'test-book',
+  link: 'https://example.com',
+  description: 'Test recipes',
+  recipeAmount: 3,
+} satisfies Source;
+
+const wholeMilk = {
+  name: 'Whole milk',
+  slug: 'whole-milk',
+  type: 'other',
+  categories: [],
+  refs: [],
+  ingredients: [],
+} satisfies RootIngredient;
+
+const recipes: Recipe[] = [
+  {
+    name: 'Ordinary Milk Drink',
+    slug: 'ordinary-milk-drink',
+    preparation: 'shaken',
+    served_on: 'up',
+    glassware: 'coupe',
+    ingredients: [{ ...wholeMilk, quantity: { amount: 1, unit: 'oz' } }],
+    source,
+    attributions: [],
+    refs: [],
+  },
+  {
+    name: 'Clarified Drink',
+    slug: 'clarified-drink',
+    preparation: 'stirred',
+    techniques: [
+      {
+        technique: 'clarification',
+        method: 'milk',
+        milk_type: 'Whole milk',
+        quantity: { amount: 4, unit: 'oz' },
+      },
+    ],
+    served_on: 'up',
+    glassware: 'coupe',
+    ingredients: [],
+    source,
+    attributions: [],
+    refs: [],
+  },
+  {
+    name: 'Coconut Clarified Drink',
+    slug: 'coconut-clarified-drink',
+    preparation: 'stirred',
+    techniques: [
+      {
+        technique: 'clarification',
+        method: 'milk',
+        milk_type: 'Coconut milk',
+        quantity: { amount: 4, unit: 'oz' },
+      },
+    ],
+    served_on: 'up',
+    glassware: 'coupe',
+    ingredients: [],
+    source,
+    attributions: [],
+    refs: [],
+  },
+];
+
+describe('getRecipesForIngredient', () => {
+  beforeEach(() => {
+    vi.mocked(getAllRecipes).mockResolvedValue(recipes);
+  });
+
+  it('includes recipes that use an ingredient as a clarification material', async () => {
+    const { getRecipesForIngredient } = await import('./ingredients');
+
+    const relatedRecipes = await getRecipesForIngredient(wholeMilk);
+
+    expect(relatedRecipes.map((recipe) => recipe.name)).toEqual([
+      'Clarified Drink',
+      'Ordinary Milk Drink',
+    ]);
+  });
+});

--- a/packages/data/src/modules/ingredients.ts
+++ b/packages/data/src/modules/ingredients.ts
@@ -165,9 +165,21 @@ export const getSubstitutesForIngredient = memo(
 export const getRecipesForIngredient = memo(
   async (ingredient: RootIngredient): Promise<Recipe[]> => {
     const allRecipes = await getAllRecipes();
-    const relatedRecipes = allRecipes.filter((recipe) =>
-      recipe.ingredients.some((i) => i.slug === ingredient.slug),
-    );
+    const relatedRecipes = allRecipes.filter((recipe) => {
+      const isDirectIngredient = recipe.ingredients.some(
+        (recipeIngredient) => recipeIngredient.slug === ingredient.slug,
+      );
+      const isTechniqueMaterial = (recipe.techniques ?? []).some((technique) =>
+        match(technique)
+          .with(
+            { technique: 'clarification', method: 'milk' },
+            ({ milk_type: milkType }) => slugify(milkType) === ingredient.slug,
+          )
+          .exhaustive(),
+      );
+
+      return isDirectIngredient || isTechniqueMaterial;
+    });
 
     return toAlphaSort(relatedRecipes);
   },

--- a/packages/data/src/modules/recipes.test.ts
+++ b/packages/data/src/modules/recipes.test.ts
@@ -44,3 +44,23 @@ describe('getRecentlyAddedRecipes', () => {
     ]);
   });
 });
+
+describe('getRecipe', () => {
+  it('loads authored recipe techniques from the plural array field', async () => {
+    const { getRecipe } = await import('./recipes');
+
+    const recipe = await getRecipe(
+      { type: 'youtube-channel', slug: 'truffles-on-the-rocks' },
+      'clarified-new-york-sour',
+    );
+
+    expect(recipe.techniques).toEqual([
+      {
+        technique: 'clarification',
+        method: 'milk',
+        milk_type: 'Whole milk',
+        quantity: { amount: 5, unit: 'oz' },
+      },
+    ]);
+  });
+});

--- a/packages/data/src/modules/recipes.ts
+++ b/packages/data/src/modules/recipes.ts
@@ -22,6 +22,8 @@ function toAlphaSort<I extends { name: string }>(arr: I[]) {
   return arr.toSorted((a, b) => a.name.localeCompare(b.name));
 }
 
+type RecipeData = Omit<Recipe, 'chapter' | 'slug' | 'source'>;
+
 export const getRecipe = memo(
   async (
     source: {
@@ -41,7 +43,7 @@ export const getRecipe = memo(
 
     // If no chapter provided, try flat path first, then search chapter directories
     if (!chapter) {
-      const data = await readJSONFile<Omit<Recipe, 'source' | 'slug'>>(directPath);
+      const data = await readJSONFile<RecipeData>(directPath);
       if (!data) {
         // Search in chapter directories using glob
         const sourcePath = path.join(RECIPE_ROOT, source.type, source.slug);
@@ -56,8 +58,7 @@ export const getRecipe = memo(
       }
     }
 
-    const data =
-      await readJSONFile<Omit<Recipe, 'source' | 'slug' | 'chapter'>>(filepath);
+    const data = await readJSONFile<RecipeData>(filepath);
 
     if (!data) throw new Error(`Recipe not found: ${filepath}`);
 

--- a/packages/data/src/types/Recipe.ts
+++ b/packages/data/src/types/Recipe.ts
@@ -30,11 +30,19 @@ export type Chapter = {
   name: string;
 };
 
+export type RecipeTechnique = {
+  technique: 'clarification';
+  method: 'milk';
+  milk_type: string;
+  quantity: RecipeIngredient['quantity'];
+};
+
 export type Recipe = {
   name: string;
   slug: string;
   chapter?: Chapter;
   preparation: 'built' | 'shaken' | 'stirred' | 'blended' | 'flash blended' | 'swizzled';
+  techniques?: RecipeTechnique[];
   served_on: 'big rock' | 'up' | 'crushed ice' | 'blended' | 'ice cubes';
   glassware:
     | 'old fashioned'


### PR DESCRIPTION
## Summary

- add strict recipe-level milk clarification with canonical milk type and quantity
- keep clarification milk exclusively in technique specs, outside the served ingredient list
- document milk clarification in a dedicated Techniques section without adding a recipe badge
- share serving scaling and unit conversion between ingredients and technique materials
- index both canonical technique names and formatted milk-specific labels in recipe search
- retain ingredient-page relationships and floating-reference tracking for technique materials
- migrate Clarified New York Sour, After Eight, and Rios Del Miel

## Why

Ingredient techniques could describe clarified juice or a milk-washed spirit, but the data model had no way to identify clarification applied to the complete cocktail. Clarification milk is a processing input, so this models its canonical identity and quantity on the recipe technique without presenting it as a served ingredient. The dedicated Techniques section keeps generated technique facts separate from source-authored instructions.

Part of #325.

## Validation

- focused validator, relation, search, ingredient-list, and recipe-page tests
- `yarn lint`
- `yarn check-data`
- pre-push suite: 38 files, 366 tests