### PR TITLE
Fix Git hook friendly names

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,7 +1,7 @@
-[hook "pre-commit"]
+[hook "nano-staged"]
 	event = pre-commit
 	command = sh -c 'yarn nano-staged'
 
-[hook "pre-push"]
+[hook "quality-checks"]
 	event = pre-push
 	command = sh -c 'yarn lint && yarn test && yarn check-data'


### PR DESCRIPTION
## Summary

- rename repo-local Git hook friendly names so they no longer collide with built-in hook event names
- keep the existing `pre-commit` and `pre-push` events and commands unchanged

## Why

Git 2.55 rejects hook friendly names that match known event names. The previous `[hook "pre-commit"]` and `[hook "pre-push"]` sections caused Git commands such as `git pull` to fail before doing any work.

## Validation

- `git hook list --show-scope pre-commit`
- `git hook list --show-scope pre-push`
- pre-push hook during `git push`: formatting, tests, and `check-data` all passed
  - 39 test files / 371 tests passed
