### PR TITLE
Speed up production build

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -3,6 +3,10 @@ const nextConfig = {
   output: 'export',
   basePath: process.env.NEXT_PUBLIC_BASE_PATH || '/cocktails',
   reactStrictMode: true,
+  experimental: {
+    cpus: 8,
+    staticGenerationMaxConcurrency: 4,
+  },
   // TODO: enable
   // typedRoutes: true,
 };

--- a/packages/data/src/modules/recipes.ts
+++ b/packages/data/src/modules/recipes.ts
@@ -87,6 +87,7 @@ export const getRecipe = memo(
       source: sourceData,
     };
   },
+  (source, recipe, chapter) => `${source.type}/${source.slug}/${chapter ?? ''}/${recipe}`,
 );
 
 export const getAllRecipes = memo(async (): Promise<Recipe[]> => {
@@ -157,18 +158,20 @@ export const getAllRecipes = memo(async (): Promise<Recipe[]> => {
   return toAlphaSort(allRecipes);
 });
 
-export const getRecipesPerSource = async (): Promise<{
-  [sourceType: string]: { [sourceSlug: string]: Recipe[] | undefined };
-}> => {
-  const recipes = await getAllRecipes();
+export const getRecipesPerSource = memo(
+  async (): Promise<{
+    [sourceType: string]: { [sourceSlug: string]: Recipe[] | undefined };
+  }> => {
+    const recipes = await getAllRecipes();
 
-  const bySourceType = Object.groupBy(recipes, (recipe) => recipe.source.type);
-  return Object.fromEntries(
-    Object.entries(bySourceType).map(([type, recipes]) => {
-      return [type, Object.groupBy(recipes, (recipe) => recipe.source.slug)];
-    }),
-  );
-};
+    const bySourceType = Object.groupBy(recipes, (recipe) => recipe.source.type);
+    return Object.fromEntries(
+      Object.entries(bySourceType).map(([type, recipes]) => {
+        return [type, Object.groupBy(recipes, (recipe) => recipe.source.slug)];
+      }),
+    );
+  },
+);
 
 export const getRecipesFromSource = memo(
   async (source: Pick<Source, 'slug' | 'type'>): Promise<Recipe[]> => {


### PR DESCRIPTION
## Summary

Speed up the static production build by reducing Next's static generation worker pressure and avoiding repeated recipe data work during the build.

## Why

The production build is dominated by static generation/export for 4,057 pages. On this machine, the default 17 static workers caused high system time and slower wall-clock builds. Capping the worker count to 8 with lower per-worker concurrency reduced I/O contention while preserving parallelism.

The data-layer memoization updates also make repeated recipe/source lookups reuse stable cache keys during metadata/page generation.

## Benchmark

Clean build command used for both runs:

```bash
rm -rf apps/web/.next apps/web/out
NEXT_TELEMETRY_DISABLED=1 /usr/bin/time -p yarn workspace @cocktails/web build
```

Current `origin/main` control:

- Wall time: 27.60s
- Static page generation: 11.6s
- sys time: 67.61s

This branch:

- Wall time: 24.11s
- Static page generation: 7.9s
- sys time: 42.38s

That is roughly a 12.6% wall-clock improvement, with the static page generation phase about 31.9% faster.

## Validation

- `yarn vitest --run packages/data/src/modules/recipes.test.ts`
- `yarn tsc --noEmit -p apps/web/tsconfig.json`
- `NEXT_TELEMETRY_DISABLED=1 /usr/bin/time -p yarn workspace @cocktails/web build`
