### PR TITLE
Speed up PR preview workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,16 +8,20 @@ permissions:
   contents: write
   pull-requests: write
 
-concurrency: preview-${{ github.ref }}
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   preview:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
+        if: github.event.action != 'closed'
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Setup Node.js ⚙️ - Cache dependencies ⚡ - Install dependencies 🔧
         uses: ./.github/workflows/setup-node


### PR DESCRIPTION
## Summary

Speed up PR preview workflow runs by reducing expensive checkout work and cancelling obsolete preview runs.

## Why

Recent preview jobs spend most of their time before the build starts:

- Checkout: roughly 9m15s to 9m30s
- Setup/install: roughly 30s
- Build: roughly 50s
- Deploy preview: roughly 2m to 2m30s

The workflow used `fetch-depth: 0`, which fetches full history for all branches. This repo's `main` tree is about 4 MB, but `gh-pages` is about 7 GB because it contains the exported site and PR previews. That makes source checkout the dominant preview cost.

## Changes

- Use `filter: blob:none` with the existing full-history checkout so build-time `git log` keeps working without downloading historical blobs.
- Skip source checkout on `pull_request.closed`; the close path only needs `rossjrw/pr-preview-action` to remove the preview.
- Key preview concurrency by PR number and cancel in-progress obsolete preview runs.

## Early Result

This PR's own preview run completed checkout in 17 seconds (`21:29:06` to `21:29:23` UTC), compared with roughly 9.5 minutes on recent preview runs.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/preview.yml"); puts "preview workflow YAML parses"'`
- Live preview run started successfully and passed checkout/setup with the new settings.
