### PR TITLE
Support recent recipes in shallow clones

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,13 +19,15 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Setup Node.js ⚙️ - Cache dependencies ⚡ - Install dependencies 🔧
         uses: ./.github/workflows/setup-node
 
       - name: Build with Next.js 🏗️
         run: yarn workspace @cocktails/web build
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Deploy to gh-pages 🚀
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,8 +20,7 @@ jobs:
         if: github.event.action != 'closed'
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0
-          filter: blob:none
+          fetch-depth: 1
 
       - name: Setup Node.js ⚙️ - Cache dependencies ⚡ - Install dependencies 🔧
         uses: ./.github/workflows/setup-node
@@ -31,6 +30,7 @@ jobs:
         if: github.event.action != 'closed'
         run: yarn workspace @cocktails/web build
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           NEXT_PUBLIC_BASE_PATH: /cocktails/pr-preview/pr-${{ github.event.number }}
 
       - name: Deploy PR Preview 🚀

--- a/apps/web/app/page.test.tsx
+++ b/apps/web/app/page.test.tsx
@@ -1,6 +1,44 @@
+import type { Recipe, Source } from '@cocktails/data';
+import { getRecentlyAddedRecipes } from '@cocktails/data/recipes';
+import { getAllSources } from '@cocktails/data/sources';
 import { screen, within } from '@testing-library/react';
+import { beforeEach, vi } from 'vitest';
 import { setupApp } from '#/vitest.setup';
 import HomePage from './page';
+
+vi.mock('@cocktails/data/recipes', () => ({
+  getRecentlyAddedRecipes: vi.fn(),
+}));
+
+vi.mock('@cocktails/data/sources', () => ({
+  getAllSources: vi.fn(),
+}));
+
+const testRecipe: Recipe = {
+  name: 'Daiquiri',
+  slug: 'daiquiri',
+  source: {
+    type: 'book',
+    name: 'Test Book',
+    slug: 'test-book',
+    link: 'https://example.com',
+    description: 'Test book',
+    recipeAmount: 1,
+  },
+  attributions: [],
+  ingredients: [],
+  preparation: 'shaken',
+  served_on: 'up',
+  glassware: 'coupe',
+  refs: [],
+};
+
+const testSources: Source[] = [];
+
+beforeEach(() => {
+  vi.mocked(getAllSources).mockResolvedValue(testSources);
+  vi.mocked(getRecentlyAddedRecipes).mockResolvedValue([testRecipe]);
+});
 
 describe('HomePage', () => {
   it('lists calculators alphabetically', async () => {
@@ -24,5 +62,24 @@ describe('HomePage', () => {
     expect(
       within(calculators).getByRole('link', { name: 'Juice Clarification' }),
     ).toHaveAttribute('href', '/calculators/juice-clarification');
+  });
+
+  it('links to recently added recipes when recent recipe data is available', async () => {
+    setupApp(await HomePage());
+
+    expect(screen.getByRole('link', { name: /recently added/i })).toHaveAttribute(
+      'href',
+      '/list/recently-added',
+    );
+  });
+
+  it('hides the recently added link when recent recipe data is unavailable', async () => {
+    vi.mocked(getRecentlyAddedRecipes).mockResolvedValue([]);
+
+    setupApp(await HomePage());
+
+    expect(
+      screen.queryByRole('link', { name: /recently added/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,4 +1,5 @@
 import type { Source } from '@cocktails/data';
+import { getRecentlyAddedRecipes } from '@cocktails/data/recipes';
 import { getAllSources } from '@cocktails/data/sources';
 import BookIcon from '@mui/icons-material/Book';
 import CalculatorIcon from '@mui/icons-material/Calculate';
@@ -57,7 +58,10 @@ function SourceListItem({ source }: { source: Source }) {
 }
 
 export default async function HomePage() {
-  const sources = await getAllSources();
+  const [sources, recentlyAddedRecipes] = await Promise.all([
+    getAllSources(),
+    getRecentlyAddedRecipes(),
+  ]);
 
   const {
     book: books = [],
@@ -80,16 +84,18 @@ export default async function HomePage() {
               </ListItemButton>
             </ListItem>
           </Link>
-          <Link href={getRecentlyAddedUrl()}>
-            <ListItem disablePadding divider secondaryAction={<ChevronRightIcon />}>
-              <ListItemButton>
-                <ListItemIcon>
-                  <HistoryIcon />
-                </ListItemIcon>
-                <ListItemText primary="Recently Added" />
-              </ListItemButton>
-            </ListItem>
-          </Link>
+          {recentlyAddedRecipes.length > 0 && (
+            <Link href={getRecentlyAddedUrl()}>
+              <ListItem disablePadding divider secondaryAction={<ChevronRightIcon />}>
+                <ListItemButton>
+                  <ListItemIcon>
+                    <HistoryIcon />
+                  </ListItemIcon>
+                  <ListItemText primary="Recently Added" />
+                </ListItemButton>
+              </ListItem>
+            </Link>
+          )}
         </Paper>
         <li>
           <ul>

--- a/packages/data/src/modules/recipes.test.ts
+++ b/packages/data/src/modules/recipes.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const execFileMocks = vi.hoisted(() => {
   const promise = vi.fn();
@@ -12,6 +12,16 @@ vi.mock('node:child_process', () => ({
   execFile: execFileMocks.callback,
 }));
 
+beforeEach(() => {
+  vi.resetModules();
+  execFileMocks.promise.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
 describe('getRecentlyAddedRecipes', () => {
   it('orders recipes by git file-add date instead of recipe name', async () => {
     const repoRoot = process.cwd();
@@ -24,8 +34,11 @@ describe('getRecentlyAddedRecipes', () => {
     ].join('\n');
 
     execFileMocks.promise.mockImplementation((command, args, options) => {
-      if (args.includes('rev-parse')) {
+      if (args.includes('--show-toplevel')) {
         return Promise.resolve({ stdout: `${repoRoot}\n`, stderr: '' });
+      }
+      if (args.includes('--is-shallow-repository')) {
+        return Promise.resolve({ stdout: 'false\n', stderr: '' });
       }
 
       expect(command).toBe('git');
@@ -42,6 +55,115 @@ describe('getRecentlyAddedRecipes', () => {
       'Belmont Jewel',
       '9th Wonder',
     ]);
+  });
+
+  it('uses GitHub commit data when local git history is shallow', async () => {
+    const repoRoot = process.cwd();
+    const fetchMock = vi.fn(async (url: URL | string) => {
+      const requestUrl = new URL(String(url));
+
+      if (requestUrl.pathname === '/repos/SBoudrias/cocktails/commits') {
+        expect(requestUrl.searchParams.get('path')).toBe('packages/data/data/recipes');
+        expect(requestUrl.searchParams.get('sha')).toBe('test-sha');
+
+        if (requestUrl.searchParams.get('page') === '2') {
+          return Response.json([]);
+        }
+
+        return Response.json([
+          {
+            sha: 'newer',
+            commit: { committer: { date: '2026-05-18T09:00:00Z' } },
+          },
+          {
+            sha: 'older',
+            commit: { committer: { date: '2026-05-16T13:10:12Z' } },
+          },
+        ]);
+      }
+
+      if (requestUrl.pathname === '/repos/SBoudrias/cocktails/commits/newer') {
+        return Response.json({
+          files: [
+            {
+              filename:
+                'packages/data/data/recipes/youtube-channel/educated-barfly/snake-eyes.json',
+              status: 'added',
+            },
+            {
+              filename:
+                'packages/data/data/recipes/youtube-channel/anders-erickson/belmont-jewel.json',
+              status: 'added',
+            },
+          ],
+        });
+      }
+
+      if (requestUrl.pathname === '/repos/SBoudrias/cocktails/commits/older') {
+        return Response.json({
+          files: [
+            {
+              filename:
+                'packages/data/data/recipes/youtube-channel/educated-barfly/9th-wonder.json',
+              status: 'added',
+            },
+          ],
+        });
+      }
+
+      throw new Error(`Unexpected GitHub API URL: ${requestUrl.href}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubEnv('GITHUB_REPOSITORY', 'SBoudrias/cocktails');
+    vi.stubEnv('GITHUB_SHA', 'test-sha');
+
+    execFileMocks.promise.mockImplementation((command, args) => {
+      expect(command).toBe('git');
+      if (args.includes('--show-toplevel')) {
+        return Promise.resolve({ stdout: `${repoRoot}\n`, stderr: '' });
+      }
+      if (args.includes('--is-shallow-repository')) {
+        return Promise.resolve({ stdout: 'true\n', stderr: '' });
+      }
+
+      throw new Error(`Unexpected git args: ${args.join(' ')}`);
+    });
+
+    const { getRecentlyAddedRecipes } = await import('./recipes');
+    const recipes = await getRecentlyAddedRecipes();
+
+    expect(recipes.map((recipe) => recipe.name)).toEqual([
+      'Snake Eyes',
+      'Belmont Jewel',
+      '9th Wonder',
+    ]);
+  });
+
+  it('returns no recently added recipes when the shallow clone fallback fails', async () => {
+    const repoRoot = process.cwd();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('Network unavailable');
+      }),
+    );
+    vi.stubEnv('GITHUB_REPOSITORY', 'SBoudrias/cocktails');
+    vi.stubEnv('GITHUB_SHA', 'test-sha');
+
+    execFileMocks.promise.mockImplementation((command, args) => {
+      expect(command).toBe('git');
+      if (args.includes('--show-toplevel')) {
+        return Promise.resolve({ stdout: `${repoRoot}\n`, stderr: '' });
+      }
+      if (args.includes('--is-shallow-repository')) {
+        return Promise.resolve({ stdout: 'true\n', stderr: '' });
+      }
+
+      throw new Error(`Unexpected git args: ${args.join(' ')}`);
+    });
+
+    const { getRecentlyAddedRecipes } = await import('./recipes');
+    await expect(getRecentlyAddedRecipes()).resolves.toEqual([]);
   });
 });
 

--- a/packages/data/src/modules/recipes.ts
+++ b/packages/data/src/modules/recipes.ts
@@ -24,6 +24,262 @@ function toAlphaSort<I extends { name: string }>(arr: I[]) {
 
 type RecipeData = Omit<Recipe, 'chapter' | 'slug' | 'source'>;
 
+type RecentRecipeEntry = {
+  sourceType: Source['type'];
+  sourceSlug: string;
+  recipeSlug: string;
+  chapter?: string;
+  date: Date;
+};
+
+const recentlyAddedRecipeLimit = 30;
+const githubApiMaxPages = 3;
+
+function isSourceType(sourceType: string | undefined): sourceType is Source['type'] {
+  return (
+    sourceType === 'book' || sourceType === 'youtube-channel' || sourceType === 'podcast'
+  );
+}
+
+function parseRecentRecipePath(
+  recipeRelPath: string,
+  filename: string,
+  date: Date,
+): RecentRecipeEntry | null {
+  if (!filename.startsWith(`${recipeRelPath}/`)) return null;
+  if (!filename.endsWith('.json') || filename.includes('_source.json')) return null;
+
+  const parts = filename.slice(recipeRelPath.length + 1).split('/');
+  const sourceType = parts[0];
+  const sourceSlug = parts[1];
+
+  if (!isSourceType(sourceType) || !sourceSlug) return null;
+
+  if (parts.length === 3) {
+    const recipeFilename = parts[2];
+    if (!recipeFilename) return null;
+
+    return {
+      sourceType,
+      sourceSlug,
+      recipeSlug: path.basename(recipeFilename, '.json'),
+      date,
+    };
+  }
+
+  if (parts.length === 4) {
+    const chapter = parts[2];
+    const recipeFilename = parts[3];
+    if (!chapter || !recipeFilename) return null;
+
+    return {
+      sourceType,
+      sourceSlug,
+      recipeSlug: path.basename(recipeFilename, '.json'),
+      chapter,
+      date,
+    };
+  }
+
+  return null;
+}
+
+function getRecentRecipeKey(entry: RecentRecipeEntry): string {
+  return `${entry.sourceType}/${entry.sourceSlug}/${entry.chapter ?? ''}/${entry.recipeSlug}`;
+}
+
+async function resolveGitRecipeContext(): Promise<{
+  repoRoot: string;
+  recipeRelPath: string;
+}> {
+  const { stdout: repoRootRaw } = await execFile(
+    'git',
+    ['rev-parse', '--show-toplevel'],
+    {
+      cwd: RECIPE_ROOT,
+    },
+  );
+  const repoRoot = repoRootRaw.trim();
+
+  return {
+    repoRoot,
+    recipeRelPath: path.relative(repoRoot, RECIPE_ROOT),
+  };
+}
+
+async function hasFullGitHistory(repoRoot: string): Promise<boolean> {
+  const { stdout } = await execFile('git', ['rev-parse', '--is-shallow-repository'], {
+    cwd: repoRoot,
+  });
+
+  return stdout.trim() !== 'true';
+}
+
+function getGitHubRepository(): { owner: string; repo: string } | null {
+  const [owner, repo, extra] = (process.env.GITHUB_REPOSITORY ?? '').split('/');
+  if (!owner || !repo || extra) return null;
+
+  return { owner, repo };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) return false;
+  return true;
+}
+
+function getObjectProperty(value: unknown, key: string): unknown {
+  if (!isRecord(value)) return undefined;
+  return value[key];
+}
+
+function getStringProperty(value: unknown, key: string): string | undefined {
+  const property = getObjectProperty(value, key);
+  return typeof property === 'string' ? property : undefined;
+}
+
+async function fetchGitHubJson(url: URL): Promise<unknown> {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(`GitHub API request failed: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+function getGitHubCommitDate(commit: unknown): Date | null {
+  const commitData = getObjectProperty(commit, 'commit');
+  const committer = getObjectProperty(commitData, 'committer');
+  const date = getStringProperty(committer, 'date');
+  if (!date) return null;
+
+  return new Date(date);
+}
+
+async function getRecentlyAddedRecipesFromGit({
+  repoRoot,
+  recipeRelPath,
+}: {
+  repoRoot: string;
+  recipeRelPath: string;
+}): Promise<RecentRecipeEntry[]> {
+  // --diff-filter=A: only commits that first introduced each file.
+  const { stdout: gitLog } = await execFile(
+    'git',
+    [
+      '-c',
+      'core.quotePath=false',
+      'log',
+      '--diff-filter=A',
+      '--name-only',
+      '--format=COMMIT %cI',
+      '--',
+      recipeRelPath,
+    ],
+    { cwd: repoRoot },
+  );
+
+  const recent: RecentRecipeEntry[] = [];
+  const seen = new Set<string>();
+  let currentDate: Date | null = null;
+
+  for (const raw of gitLog.split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+
+    if (line.startsWith('COMMIT ')) {
+      currentDate = new Date(line.slice(7));
+    } else if (currentDate) {
+      const entry = parseRecentRecipePath(recipeRelPath, line, currentDate);
+      if (!entry) continue;
+
+      const key = getRecentRecipeKey(entry);
+      if (!seen.has(key)) {
+        seen.add(key);
+        recent.push(entry);
+      }
+    }
+  }
+
+  return recent;
+}
+
+async function getRecentlyAddedRecipesFromGitHub(
+  recipeRelPath: string,
+): Promise<RecentRecipeEntry[]> {
+  const repository = getGitHubRepository();
+  if (!repository) return [];
+
+  const apiRoot = process.env.GITHUB_API_URL ?? 'https://api.github.com';
+  const recent: RecentRecipeEntry[] = [];
+  const seen = new Set<string>();
+
+  try {
+    for (let page = 1; page <= githubApiMaxPages; page++) {
+      if (recent.length >= recentlyAddedRecipeLimit) break;
+
+      const commitsUrl = new URL(
+        `/repos/${repository.owner}/${repository.repo}/commits`,
+        apiRoot,
+      );
+      commitsUrl.searchParams.set('path', recipeRelPath);
+      commitsUrl.searchParams.set('per_page', '100');
+      commitsUrl.searchParams.set('page', String(page));
+      if (process.env.GITHUB_SHA) {
+        commitsUrl.searchParams.set('sha', process.env.GITHUB_SHA);
+      }
+
+      const commits = await fetchGitHubJson(commitsUrl);
+      if (!Array.isArray(commits) || commits.length === 0) break;
+
+      for (const commit of commits) {
+        if (recent.length >= recentlyAddedRecipeLimit) break;
+
+        const sha = getStringProperty(commit, 'sha');
+        const date = getGitHubCommitDate(commit);
+        if (!sha || !date) continue;
+
+        const commitUrl = new URL(
+          `/repos/${repository.owner}/${repository.repo}/commits/${sha}`,
+          apiRoot,
+        );
+        const commitDetails = await fetchGitHubJson(commitUrl);
+        const files = getObjectProperty(commitDetails, 'files');
+        if (!Array.isArray(files)) continue;
+
+        for (const file of files) {
+          if (getStringProperty(file, 'status') !== 'added') continue;
+
+          const filename = getStringProperty(file, 'filename');
+          if (!filename) continue;
+
+          const entry = parseRecentRecipePath(recipeRelPath, filename, date);
+          if (!entry) continue;
+
+          const key = getRecentRecipeKey(entry);
+          if (!seen.has(key)) {
+            seen.add(key);
+            recent.push(entry);
+          }
+
+          if (recent.length >= recentlyAddedRecipeLimit) break;
+        }
+      }
+    }
+  } catch {
+    return [];
+  }
+
+  return recent;
+}
+
 export const getRecipe = memo(
   async (
     source: {
@@ -181,96 +437,15 @@ export const getRecipesFromSource = memo(
 );
 
 export const getRecentlyAddedRecipes = memo(async (): Promise<Recipe[]> => {
-  const { stdout: repoRootRaw } = await execFile(
-    'git',
-    ['rev-parse', '--show-toplevel'],
-    {
-      cwd: RECIPE_ROOT,
-    },
-  );
-  const repoRoot = repoRootRaw.trim();
-  const recipeRelPath = path.relative(repoRoot, RECIPE_ROOT);
-
-  // --diff-filter=A: only commits that first introduced each file.
-  const { stdout: gitLog } = await execFile(
-    'git',
-    [
-      '-c',
-      'core.quotePath=false',
-      'log',
-      '--diff-filter=A',
-      '--name-only',
-      '--format=COMMIT %cI',
-      '--',
-      recipeRelPath,
-    ],
-    { cwd: repoRoot },
-  );
-
-  const seen = new Set<string>();
-  const recent: Array<{
-    sourceType: Source['type'];
-    sourceSlug: string;
-    recipeSlug: string;
-    chapter?: string;
-    date: Date;
-  }> = [];
-
-  let currentDate: Date | null = null;
-
-  for (const raw of gitLog.split('\n')) {
-    const line = raw.trim();
-    if (!line) continue;
-
-    if (line.startsWith('COMMIT ')) {
-      currentDate = new Date(line.slice(7));
-    } else if (currentDate && line.endsWith('.json') && !line.includes('_source.json')) {
-      const relToRecipes = path.relative(recipeRelPath, line);
-      const parts = relToRecipes.split('/');
-
-      let entry: (typeof recent)[number] | null = null;
-
-      const sourceType = parts[0];
-      const sourceSlug = parts[1];
-
-      if (parts.length === 3) {
-        const filename = parts[2];
-        if (sourceType && sourceSlug && filename) {
-          entry = {
-            sourceType: sourceType as Source['type'],
-            sourceSlug,
-            recipeSlug: path.basename(filename, '.json'),
-            date: currentDate,
-          };
-        }
-      } else if (parts.length === 4) {
-        const chapter = parts[2];
-        const filename = parts[3];
-        if (sourceType && sourceSlug && chapter && filename) {
-          entry = {
-            sourceType: sourceType as Source['type'],
-            sourceSlug,
-            recipeSlug: path.basename(filename, '.json'),
-            chapter,
-            date: currentDate,
-          };
-        }
-      }
-
-      if (entry) {
-        const key = `${entry.sourceType}/${entry.sourceSlug}/${entry.chapter ?? ''}/${entry.recipeSlug}`;
-        if (!seen.has(key)) {
-          seen.add(key);
-          recent.push(entry);
-        }
-      }
-    }
-  }
+  const { repoRoot, recipeRelPath } = await resolveGitRecipeContext();
+  const recent = (await hasFullGitHistory(repoRoot))
+    ? await getRecentlyAddedRecipesFromGit({ repoRoot, recipeRelPath })
+    : await getRecentlyAddedRecipesFromGitHub(recipeRelPath);
 
   return Promise.all(
     recent
       .toSorted((a, b) => b.date.getTime() - a.date.getTime())
-      .slice(0, 30)
+      .slice(0, recentlyAddedRecipeLimit)
       .map(({ sourceType, sourceSlug, recipeSlug, chapter }) =>
         getRecipe({ type: sourceType, slug: sourceSlug }, recipeSlug, chapter),
       ),


### PR DESCRIPTION
## Summary

Allow PR preview and production deploy builds to use true shallow checkouts while keeping the Recently Added feature best-effort.

## Why

The preview workflow was still using full Git history because `getRecentlyAddedRecipes()` depended on local `git log` to find first-added recipe files. Full history is expensive in this repository because the `gh-pages` branch is very large.

This feature is useful but not important enough to block preview or production builds when history or network data is unavailable.

## Changes

- Keep the exact local `git log --diff-filter=A` path when full Git history is available.
- Detect shallow clones with `git rev-parse --is-shallow-repository`.
- In shallow clones, use the GitHub commits API as a best-effort fallback for recently added recipe JSON files.
- Return an empty recent recipe list if the GitHub fallback is unavailable or fails.
- Hide the homepage Recently Added link when there is no recent recipe data.
- Change the PR preview checkout to `fetch-depth: 1`.
- Change the production deploy checkout to `fetch-depth: 1`.
- Pass `GITHUB_TOKEN: ${{ github.token }}` to both preview and production build steps so the GitHub API fallback can authenticate.

## Validation

- `yarn vitest --run packages/data/src/modules/recipes.test.ts apps/web/app/page.test.tsx`
- `yarn tsc --noEmit -p packages/data/tsconfig.json`
- `yarn tsc --noEmit -p apps/web/tsconfig.json`
- `ruby -e 'require "yaml"; %w[.github/workflows/preview.yml .github/workflows/deploy.yml].each { |file| YAML.load_file(file); puts "#{file} parses" }'`
- `NEXT_TELEMETRY_DISABLED=1 /usr/bin/time -p yarn workspace @cocktails/web build`
