### PR TITLE
Add issue 362 YouTube recipes

### DIFF
--- a/packages/data/data/ingredients/emulsifier/fee-foamer.json
+++ b/packages/data/data/ingredients/emulsifier/fee-foamer.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Fee Foamer",
+  "type": "emulsifier"
+}

--- a/packages/data/data/ingredients/other/vanilla-bean-paste.json
+++ b/packages/data/data/ingredients/other/vanilla-bean-paste.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Vanilla bean paste",
+  "type": "other"
+}

--- a/packages/data/data/ingredients/spice/lemongrass.json
+++ b/packages/data/data/ingredients/spice/lemongrass.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Lemongrass",
+  "type": "spice"
+}

--- a/packages/data/data/ingredients/spirit/empress-1908-cucumber-lemon-gin.json
+++ b/packages/data/data/ingredients/spirit/empress-1908-cucumber-lemon-gin.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Empress 1908 Cucumber Lemon Gin",
+  "type": "spirit",
+  "categories": ["Gin"]
+}

--- a/packages/data/data/ingredients/syrup/lemongrass-and-thai-chili-syrup.json
+++ b/packages/data/data/ingredients/syrup/lemongrass-and-thai-chili-syrup.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Lemongrass and Thai Chili Syrup",
+  "type": "syrup",
+  "ingredients": [
+    {
+      "name": "Simple syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 250,
+        "unit": "ml"
+      }
+    },
+    {
+      "name": "Lemongrass",
+      "type": "spice",
+      "technique": {
+        "technique": "cut",
+        "type": "chunked"
+      },
+      "quantity": {
+        "amount": 35,
+        "unit": "gram"
+      }
+    },
+    {
+      "name": "Thai Chili",
+      "type": "spice",
+      "quantity": {
+        "amount": 2,
+        "unit": "gram"
+      }
+    }
+  ],
+  "instructions": [
+    "Blend the simple syrup, lemongrass, and Thai chili until smooth.",
+    "Filter through a coffee filter until clear.",
+    "Adjust chili to preferred heat."
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "bE1kcZJIbjI"
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/9th-wonder.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/9th-wonder.json
@@ -44,11 +44,21 @@
     "Strain into a chilled coupe",
     "Garnish with a lemon wheel"
   ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Erick Castro"
+    }
+  ],
   "refs": [
     {
       "type": "youtube",
       "videoId": "mui53iIiIVE",
       "start": 90
+    },
+    {
+      "type": "youtube",
+      "videoId": "fPB3-wUqHu0"
     }
   ]
 }

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/amalfi-coastline.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/amalfi-coastline.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Amalfi Coastline",
+  "preparation": "shaken",
+  "served_on": "up",
+  "glassware": "coupe",
+  "ingredients": [
+    {
+      "name": "Fee Foamer",
+      "type": "emulsifier",
+      "quantity": {
+        "amount": 3,
+        "maximum": 4,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Simple syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Passion fruit syrup",
+      "type": "category",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lemon juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Aperol",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Gin",
+      "type": "category",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "dry sparkling wine",
+      "type": "category",
+      "technique": {
+        "technique": "application",
+        "method": "top"
+      },
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Shake all ingredients except sparkling wine with ice.",
+    "Strain and top with prosecco.",
+    "Garnish with a freeze dried blood orange wheel."
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "FOjO73ues48",
+      "start": 251
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/chin-up.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/chin-up.json
@@ -61,6 +61,10 @@
     {
       "type": "youtube",
       "videoId": "rFg0VCTdAhk"
+    },
+    {
+      "type": "youtube",
+      "videoId": "flQXggP7X3I"
     }
   ]
 }

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/italian-buck.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/italian-buck.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Italian Buck",
+  "preparation": "built",
+  "served_on": "ice cubes",
+  "glassware": "highball",
+  "ingredients": [
+    {
+      "name": "Lime juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Ginger syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Cynar",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Amaro Montenegro",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Ginger beer",
+      "type": "soda",
+      "technique": {
+        "technique": "application",
+        "method": "top"
+      },
+      "quantity": {
+        "amount": 1,
+        "unit": "unit"
+      }
+    }
+  ],
+  "instructions": ["Top with ginger beer.", "Garnish with a lime twist."],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "FOjO73ues48",
+      "start": 452
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/olivette.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/olivette.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Olivette",
+  "preparation": "stirred",
+  "served_on": "up",
+  "glassware": "coupe",
+  "ingredients": [
+    {
+      "name": "Saline",
+      "type": "other",
+      "quantity": {
+        "amount": 5,
+        "unit": "drop"
+      }
+    },
+    {
+      "name": "St-Germain",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Cocchi Americano",
+      "type": "wine",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Dry vermouth",
+      "type": "category",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Gin",
+      "type": "category",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Stir all ingredients with ice.", "Strain and garnish with an olive."],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "FOjO73ues48",
+      "start": 603
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/make-and-drink/lava-flow.json
+++ b/packages/data/data/recipes/youtube-channel/make-and-drink/lava-flow.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Lava Flow",
+  "preparation": "blended",
+  "served_on": "blended",
+  "glassware": "hurricane",
+  "ingredients": [
+    {
+      "name": "banana",
+      "type": "fruit",
+      "technique": {
+        "technique": "temperature",
+        "method": "frozen"
+      },
+      "quantity": {
+        "amount": 0.5,
+        "unit": "unit"
+      }
+    },
+    {
+      "name": "cream syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Pineapple juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 2,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Banana liqueur",
+      "type": "category",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Kōloa Kauaʻi Coconut Rum",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Hamilton White Stache",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "xanthan gum",
+      "type": "emulsifier",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "strawberry syrup",
+      "type": "syrup",
+      "technique": {
+        "technique": "application",
+        "method": "float",
+        "instructions": "Use as the strawberry component of the lava flow; the source lists the syrup prep but no cocktail amount."
+      },
+      "quantity": {
+        "amount": 1,
+        "unit": "unit"
+      }
+    }
+  ],
+  "instructions": [
+    "Blend the pineapple juice, cream syrup, banana liqueur, rums, frozen banana, xanthan gum, and 110 grams nugget or crushed ice.",
+    "Pour with the strawberry syrup to create the lava flow effect."
+  ],
+  "attributions": [
+    {
+      "relation": "bar",
+      "source": "Four Seasons Maui",
+      "location": "Maui, HI"
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "Ow8wtNvWKNc"
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/make-and-drink/pineapple-milk.json
+++ b/packages/data/data/recipes/youtube-channel/make-and-drink/pineapple-milk.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Pineapple Milk",
+  "preparation": "blended",
+  "served_on": "blended",
+  "glassware": "hurricane",
+  "ingredients": [
+    {
+      "name": "pineapple",
+      "type": "fruit",
+      "technique": {
+        "technique": "cut",
+        "type": "chunked"
+      },
+      "quantity": {
+        "amount": 75,
+        "unit": "gram"
+      }
+    },
+    {
+      "name": "Vanilla bean paste",
+      "type": "other",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "tsp"
+      }
+    },
+    {
+      "name": "Brown sugar",
+      "type": "other",
+      "quantity": {
+        "amount": 1,
+        "unit": "tbsp"
+      }
+    },
+    {
+      "name": "Pineapple juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 3,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Whole milk",
+      "type": "other",
+      "quantity": {
+        "amount": 4,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Cognac",
+      "type": "category",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Blended Lightly-aged Rum",
+      "type": "category",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Blend all ingredients with 1/2 cup of ice."],
+  "attributions": [
+    {
+      "relation": "book",
+      "source": "The Gentleman's Companion"
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "Euuhf8bF_xc"
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/truffles-on-the-rocks/cucumber-lemon-gimlet.json
+++ b/packages/data/data/recipes/youtube-channel/truffles-on-the-rocks/cucumber-lemon-gimlet.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Cucumber Lemon Gimlet",
+  "preparation": "shaken",
+  "served_on": "up",
+  "glassware": "coupe",
+  "ingredients": [
+    {
+      "name": "Basil leaves",
+      "type": "other",
+      "quantity": {
+        "amount": 1,
+        "unit": "unit"
+      }
+    },
+    {
+      "name": "Saline",
+      "type": "other",
+      "quantity": {
+        "amount": 2,
+        "maximum": 3,
+        "unit": "drop"
+      }
+    },
+    {
+      "name": "Lemongrass and Thai Chili Syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lime juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Empress 1908 Cucumber Lemon Gin",
+      "type": "spirit",
+      "quantity": {
+        "amount": 2,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Use a generous handful of basil leaves.",
+    "Shake hard with ice and fine strain into a chilled coupe.",
+    "Garnish with a fresh basil leaf."
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "bE1kcZJIbjI"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- process recipe-bearing videos from #362
- add new recipe data for Educated Barfly, Make and Drink, and Truffles On The Rocks
- add supporting ingredients/categories and append refs for existing Chin Up and 9th Wonder recipes

## Notes
- skipped non-recipe videos where the fetched metadata did not include recipe details
- preserves source uncertainty for the Lava Flow strawberry syrup amount in the recipe instructions

## Validation
- yarn check-data
- yarn lint
- yarn vitest --run

Closes #362