### PR TITLE
Process July 13 YouTube recipes

### DIFF
--- a/packages/data/data/ingredients/fruit/rhubarb.json
+++ b/packages/data/data/ingredients/fruit/rhubarb.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Rhubarb",
+  "type": "fruit"
+}

--- a/packages/data/data/ingredients/other/gorilla-grog.json
+++ b/packages/data/data/ingredients/other/gorilla-grog.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Gorilla Grog",
+  "type": "other",
+  "ingredients": [
+    {
+      "name": "passion fruit juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 1,
+        "unit": "part"
+      }
+    },
+    {
+      "name": "Orange juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 1,
+        "unit": "part"
+      }
+    },
+    {
+      "name": "guava juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 1,
+        "unit": "part"
+      }
+    },
+    {
+      "name": "Pineapple juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 1,
+        "unit": "part"
+      }
+    },
+    {
+      "name": "Lemon juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "part"
+      }
+    },
+    {
+      "name": "Orgeat",
+      "type": "category",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "part"
+      }
+    },
+    {
+      "name": "Falernum",
+      "type": "category",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "part"
+      }
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "C-dTFBiLwqo"
+    }
+  ]
+}

--- a/packages/data/data/ingredients/other/salted-cream.json
+++ b/packages/data/data/ingredients/other/salted-cream.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Salted cream",
+  "type": "other",
+  "ingredients": [
+    {
+      "name": "Heavy whipping cream",
+      "type": "other",
+      "quantity": {
+        "amount": 500,
+        "unit": "ml"
+      }
+    },
+    {
+      "name": "Salt",
+      "type": "other",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "tsp"
+      }
+    }
+  ]
+}

--- a/packages/data/data/ingredients/other/strawberry-rhubarb-sorbet.json
+++ b/packages/data/data/ingredients/other/strawberry-rhubarb-sorbet.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Strawberry Rhubarb Sorbet",
+  "type": "other",
+  "ingredients": [
+    {
+      "name": "Strawberry puree",
+      "type": "puree",
+      "quantity": {
+        "amount": 500,
+        "unit": "ml"
+      }
+    },
+    {
+      "name": "Rhubarb",
+      "type": "fruit",
+      "quantity": {
+        "amount": 150,
+        "unit": "gram"
+      }
+    },
+    {
+      "name": "white sugar",
+      "type": "other",
+      "quantity": {
+        "amount": 150,
+        "unit": "gram"
+      }
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "0hpf8ZRe1ss",
+      "start": 294
+    }
+  ]
+}

--- a/packages/data/data/ingredients/puree/strawberry-puree.json
+++ b/packages/data/data/ingredients/puree/strawberry-puree.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Strawberry puree",
+  "type": "puree"
+}

--- a/packages/data/data/ingredients/spirit/sailor-jerry-spiced-rum.json
+++ b/packages/data/data/ingredients/spirit/sailor-jerry-spiced-rum.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Sailor Jerry Spiced Rum",
+  "type": "spirit",
+  "categories": ["Spiced Rum"]
+}

--- a/packages/data/data/ingredients/spirit/ultimate-mai-tai-rum-blend.json
+++ b/packages/data/data/ingredients/spirit/ultimate-mai-tai-rum-blend.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Ultimate Mai Tai Rum Blend",
+  "type": "spirit",
+  "categories": ["Rum"],
+  "ingredients": [
+    {
+      "name": "Appleton 12",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "part"
+      }
+    },
+    {
+      "name": "Smith & Cross",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "part"
+      }
+    },
+    {
+      "name": "Planteray Xaymaca",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "part"
+      }
+    },
+    {
+      "name": "Planteray OFTD",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "part"
+      }
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "JAyQ9P_w4a8"
+    }
+  ]
+}

--- a/packages/data/data/recipes/book/easy-tiki/02_Modern Recipes/breakfast-mai-tai.json
+++ b/packages/data/data/recipes/book/easy-tiki/02_Modern Recipes/breakfast-mai-tai.json
@@ -80,6 +80,10 @@
     {
       "type": "youtube",
       "videoId": "AT-VFGUD_Ds"
+    },
+    {
+      "type": "youtube",
+      "videoId": "H8FytOh2ZJs"
     }
   ]
 }

--- a/packages/data/data/recipes/book/smugglers-cove/09_Eight Essential Exotic Elixirs/navy-grog.json
+++ b/packages/data/data/recipes/book/smugglers-cove/09_Eight Essential Exotic Elixirs/navy-grog.json
@@ -79,6 +79,11 @@
     {
       "type": "youtube",
       "videoId": "ZtRwS65Xz_Q"
+    },
+    {
+      "type": "youtube",
+      "videoId": "JniZAbdeBo8",
+      "start": 165
     }
   ]
 }

--- a/packages/data/data/recipes/youtube-channel/anders-erickson/aviation.json
+++ b/packages/data/data/recipes/youtube-channel/anders-erickson/aviation.json
@@ -62,6 +62,11 @@
       "type": "youtube",
       "videoId": "RRvfkkSjceM",
       "start": 136
+    },
+    {
+      "type": "youtube",
+      "videoId": "tjIm_48p9RY",
+      "start": 645
     }
   ]
 }

--- a/packages/data/data/recipes/youtube-channel/anders-erickson/jungle-bird.json
+++ b/packages/data/data/recipes/youtube-channel/anders-erickson/jungle-bird.json
@@ -65,6 +65,11 @@
       "type": "youtube",
       "videoId": "cup9PY32Sd4",
       "start": 322
+    },
+    {
+      "type": "youtube",
+      "videoId": "VhwLm7dkp20",
+      "start": 452
     }
   ]
 }

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/gun-metal-blue.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/gun-metal-blue.json
@@ -51,6 +51,10 @@
     {
       "type": "youtube",
       "videoId": "NIZEI5gxH1o"
+    },
+    {
+      "type": "youtube",
+      "videoId": "Bk6MjJcGIaI"
     }
   ]
 }

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/margaritas-and-cream.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/margaritas-and-cream.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Margaritas & Cream",
+  "preparation": "blended",
+  "served_on": "blended",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Strawberry Rhubarb Sorbet",
+      "type": "other",
+      "quantity": {
+        "amount": 130,
+        "unit": "gram"
+      }
+    },
+    {
+      "name": "Lime juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Tequila (Blanco)",
+      "type": "category",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Salted cream",
+      "type": "other",
+      "technique": {
+        "technique": "application",
+        "method": "top"
+      },
+      "quantity": {
+        "amount": 1,
+        "unit": "unit"
+      }
+    }
+  ],
+  "attributions": [
+    {
+      "relation": "bar",
+      "source": "Schmuck",
+      "location": "New York, NY"
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "0hpf8ZRe1ss",
+      "start": 648
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/jason-miller/the-lost-safari.json
+++ b/packages/data/data/recipes/youtube-channel/jason-miller/the-lost-safari.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "The Lost Safari",
+  "preparation": "shaken",
+  "served_on": "ice cubes",
+  "glassware": "tiki",
+  "ingredients": [
+    {
+      "name": "Grenadine",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Gorilla Grog",
+      "type": "other",
+      "quantity": {
+        "amount": 3,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Myers's Original Dark Rum",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Sailor Jerry Spiced Rum",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    }
+  ],
+  "attributions": [
+    {
+      "relation": "bar",
+      "source": "Trader Sam's"
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "C-dTFBiLwqo"
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/make-and-drink/daiquiri-on-ice.json
+++ b/packages/data/data/recipes/youtube-channel/make-and-drink/daiquiri-on-ice.json
@@ -1,36 +1,37 @@
 {
   "$schema": "../../../../schemas/recipe.schema.json",
-  "name": "The Oriental",
+  "name": "Daiquiri on Ice",
   "preparation": "shaken",
-  "served_on": "up",
-  "glassware": "coupe",
+  "served_on": "ice cubes",
+  "glassware": "old fashioned",
   "ingredients": [
     {
-      "name": "Lime juice",
-      "type": "juice",
+      "name": "Simple syrup",
+      "type": "syrup",
+      "brix": 66,
       "quantity": {
         "amount": 0.5,
         "unit": "oz"
       }
     },
     {
-      "name": "Triple Sec",
-      "type": "category",
+      "name": "Lime juice",
+      "type": "juice",
       "quantity": {
-        "amount": 0.75,
+        "amount": 1,
         "unit": "oz"
       }
     },
     {
-      "name": "Sweet vermouth",
+      "name": "Overproof Rum",
       "type": "category",
       "quantity": {
-        "amount": 0.75,
+        "amount": 0.5,
         "unit": "oz"
       }
     },
     {
-      "name": "Whiskey (Rye)",
+      "name": "Blended Lightly-aged Rum",
       "type": "category",
       "quantity": {
         "amount": 1.5,
@@ -38,15 +39,12 @@
       }
     }
   ],
+  "instructions": ["Garnish with a lime wedge."],
   "refs": [
     {
       "type": "youtube",
-      "videoId": "qKgCw8f50BQ",
-      "start": 56
-    },
-    {
-      "type": "youtube",
-      "videoId": "Uts74uHEVqk"
+      "videoId": "VhwLm7dkp20",
+      "start": 51
     }
   ]
 }

--- a/packages/data/data/recipes/youtube-channel/make-and-drink/planters-punch-summer.json
+++ b/packages/data/data/recipes/youtube-channel/make-and-drink/planters-punch-summer.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Planter's Punch (Summer)",
+  "preparation": "shaken",
+  "served_on": "ice cubes",
+  "glassware": "collins",
+  "ingredients": [
+    {
+      "name": "Angostura bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 4,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Simple syrup",
+      "type": "syrup",
+      "brix": 66,
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lemon juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "black tea",
+      "type": "other",
+      "technique": {
+        "technique": "temperature",
+        "method": "chilled"
+      },
+      "quantity": {
+        "amount": 2,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Jamaican Rum",
+      "type": "category",
+      "quantity": {
+        "amount": 2.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "VhwLm7dkp20",
+      "start": 157
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/make-and-drink/queens-park-swizzle-make-and-drink.json
+++ b/packages/data/data/recipes/youtube-channel/make-and-drink/queens-park-swizzle-make-and-drink.json
@@ -50,6 +50,11 @@
     {
       "type": "youtube",
       "videoId": "oNPRn-uLAR8"
+    },
+    {
+      "type": "youtube",
+      "videoId": "VhwLm7dkp20",
+      "start": 568
     }
   ]
 }

--- a/packages/data/data/recipes/youtube-channel/make-and-drink/ron-collins.json
+++ b/packages/data/data/recipes/youtube-channel/make-and-drink/ron-collins.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Ron Collins",
+  "preparation": "built",
+  "served_on": "ice cubes",
+  "glassware": "collins",
+  "ingredients": [
+    {
+      "name": "Simple syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lemon juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Blended Lightly-aged Rum",
+      "type": "category",
+      "quantity": {
+        "amount": 2,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Seltzer",
+      "type": "soda",
+      "technique": {
+        "technique": "application",
+        "method": "top"
+      },
+      "quantity": {
+        "amount": 1,
+        "unit": "unit"
+      }
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "VhwLm7dkp20",
+      "start": 275
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/make-and-drink/ultimate-mai-tai-navy-grog.json
+++ b/packages/data/data/recipes/youtube-channel/make-and-drink/ultimate-mai-tai-navy-grog.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Ultimate Mai Tai Navy Grog",
+  "preparation": "shaken",
+  "served_on": "ice cubes",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Vanilla syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lime juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Grapefruit juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Honey syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Hamilton Pimento Dram",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Ultimate Mai Tai Rum Blend",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lemon Hart 151",
+      "type": "spirit",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Seltzer",
+      "type": "soda",
+      "technique": {
+        "technique": "application",
+        "method": "top"
+      },
+      "quantity": {
+        "amount": 2,
+        "unit": "oz"
+      }
+    }
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Kevin Crossman",
+      "url": "https://ultimatemaitai.com/"
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "JniZAbdeBo8",
+      "start": 165
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/make-and-drink/ultimate-mai-tai.json
+++ b/packages/data/data/recipes/youtube-channel/make-and-drink/ultimate-mai-tai.json
@@ -40,34 +40,10 @@
       }
     },
     {
-      "name": "Appleton 12",
+      "name": "Ultimate Mai Tai Rum Blend",
       "type": "spirit",
       "quantity": {
-        "amount": 0.5,
-        "unit": "oz"
-      }
-    },
-    {
-      "name": "Smith & Cross",
-      "type": "spirit",
-      "quantity": {
-        "amount": 0.5,
-        "unit": "oz"
-      }
-    },
-    {
-      "name": "Planteray OFTD",
-      "type": "spirit",
-      "quantity": {
-        "amount": 0.5,
-        "unit": "oz"
-      }
-    },
-    {
-      "name": "Planteray Xaymaca",
-      "type": "spirit",
-      "quantity": {
-        "amount": 0.5,
+        "amount": 2,
         "unit": "oz"
       }
     }


### PR DESCRIPTION
## Summary

- Process the recipe-bearing videos from issue #376.
- Add new YouTube-channel recipes for distinct formulas from Jason Miller, Make and Drink, and The Educated Barfly.
- Add supporting component ingredients for Gorilla Grog, Margaritas & Cream components, Sailor Jerry Spiced Rum, and the Ultimate Mai Tai rum blend.
- Reuse existing recipes for duplicate/common coverage: Easy Tiki Breakfast Mai Tai for Spike's video, Make and Drink Queen's Park Swizzle for the summer video ref, and an existing Jungle Bird for the summer video ref.
- Add YouTube refs to matching existing Aviation, Gun Metal Blue, The Oriental, and Smuggler's Cove Navy Grog recipes.

## Validation

- yarn check-data
- yarn lint
- push hook: formatting, yarn vitest --run, yarn check-data

Closes #376
