### PR TITLE
Process YouTube recipes from issue 390

### DIFF
--- a/packages/data/data/categories/lemon-vodka.json
+++ b/packages/data/data/categories/lemon-vodka.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../schemas/category.schema.json",
+  "name": "Lemon Vodka",
+  "categoryType": "spirit"
+}

--- a/packages/data/data/ingredients/fruit/raspberry.json
+++ b/packages/data/data/ingredients/fruit/raspberry.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "raspberry",
+  "type": "fruit"
+}

--- a/packages/data/data/ingredients/syrup/jasmine-tea-syrup.json
+++ b/packages/data/data/ingredients/syrup/jasmine-tea-syrup.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../schemas/ingredient.schema.json",
+  "name": "Jasmine tea syrup",
+  "type": "syrup"
+}

--- a/packages/data/data/recipes/youtube-channel/anders-erickson/hurricane.json
+++ b/packages/data/data/recipes/youtube-channel/anders-erickson/hurricane.json
@@ -48,6 +48,10 @@
       "type": "youtube",
       "videoId": "3b2-jFhtCyQ",
       "start": 297
+    },
+    {
+      "type": "youtube",
+      "videoId": "ipanX7SRmOU"
     }
   ]
 }

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/21st-century.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/21st-century.json
@@ -69,6 +69,10 @@
       "type": "youtube",
       "videoId": "5I6CsA9IY1M",
       "start": 97
+    },
+    {
+      "type": "youtube",
+      "videoId": "4Lh-vhm4tt0"
     }
   ]
 }

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/cucumbertini.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/cucumbertini.json
@@ -1,20 +1,28 @@
 {
   "$schema": "../../../../schemas/recipe.schema.json",
-  "name": "Gun Metal Blue",
+  "name": "Cucumbertini",
   "preparation": "shaken",
   "served_on": "up",
-  "glassware": "coupe",
+  "glassware": "martini",
   "ingredients": [
     {
-      "name": "Cinnamon syrup",
-      "type": "syrup",
+      "name": "Lime juice",
+      "type": "juice",
       "quantity": {
-        "amount": 0.25,
+        "amount": 0.5,
         "unit": "oz"
       }
     },
     {
-      "name": "Lime juice",
+      "name": "Simple syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "cucumber juice",
       "type": "juice",
       "quantity": {
         "amount": 0.75,
@@ -22,15 +30,7 @@
       }
     },
     {
-      "name": "Peach liqueur",
-      "type": "category",
-      "quantity": {
-        "amount": 0.25,
-        "unit": "oz"
-      }
-    },
-    {
-      "name": "Blue Curaçao",
+      "name": "Elderflower liqueur",
       "type": "category",
       "quantity": {
         "amount": 0.5,
@@ -38,7 +38,7 @@
       }
     },
     {
-      "name": "Mezcal",
+      "name": "Gin",
       "type": "category",
       "quantity": {
         "amount": 1.5,
@@ -46,19 +46,18 @@
       }
     }
   ],
-  "instructions": ["Garnish with an orange coin twist and float"],
+  "attributions": [
+    {
+      "relation": "bar",
+      "source": "Pump",
+      "location": "West Hollywood, CA"
+    }
+  ],
   "refs": [
     {
       "type": "youtube",
-      "videoId": "NIZEI5gxH1o"
-    },
-    {
-      "type": "youtube",
-      "videoId": "Bk6MjJcGIaI"
-    },
-    {
-      "type": "youtube",
-      "videoId": "amV7m3Ycml8"
+      "videoId": "epleXpr5LAw",
+      "start": 569
     }
   ]
 }

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/knickerbocker.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/knickerbocker.json
@@ -63,6 +63,10 @@
     {
       "type": "youtube",
       "videoId": "JbOKgsOtb4Y"
+    },
+    {
+      "type": "youtube",
+      "videoId": "amV7m3Ycml8"
     }
   ]
 }

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/pumptini.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/pumptini.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Pumptini",
+  "preparation": "shaken",
+  "served_on": "up",
+  "glassware": "martini",
+  "ingredients": [
+    {
+      "name": "raspberry",
+      "type": "fruit",
+      "quantity": {
+        "amount": 3,
+        "unit": "unit"
+      }
+    },
+    {
+      "name": "Lime juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Simple syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Grapefruit juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Orange Liqueur",
+      "type": "category",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lemon Vodka",
+      "type": "category",
+      "quantity": {
+        "amount": 1.5,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": ["Garnish with a fresh raspberry."],
+  "attributions": [
+    {
+      "relation": "bar",
+      "source": "Pump",
+      "location": "West Hollywood, CA"
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "epleXpr5LAw",
+      "start": 342
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/spice-trade.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/spice-trade.json
@@ -46,6 +46,10 @@
     {
       "type": "youtube",
       "videoId": "NIZEI5gxH1o"
+    },
+    {
+      "type": "youtube",
+      "videoId": "amV7m3Ycml8"
     }
   ]
 }

--- a/packages/data/data/recipes/youtube-channel/educated-barfly/spicy-latina.json
+++ b/packages/data/data/recipes/youtube-channel/educated-barfly/spicy-latina.json
@@ -81,6 +81,10 @@
     {
       "type": "youtube",
       "videoId": "cb2BYQSWC2E"
+    },
+    {
+      "type": "youtube",
+      "videoId": "nQIVvxeD93M"
     }
   ]
 }

--- a/packages/data/data/recipes/youtube-channel/make-and-drink/bushwacker.json
+++ b/packages/data/data/recipes/youtube-channel/make-and-drink/bushwacker.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Bushwacker",
+  "preparation": "blended",
+  "served_on": "blended",
+  "glassware": "hurricane",
+  "ingredients": [
+    {
+      "name": "Chocolate Bitters",
+      "type": "category",
+      "quantity": {
+        "amount": 1,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "espresso",
+      "type": "other",
+      "technique": {
+        "technique": "temperature",
+        "method": "chilled"
+      },
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Cream of coconut",
+      "type": "syrup",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Half and half",
+      "type": "other",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Crème de Cacao",
+      "type": "category",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Black Blended Rum (Jamaica)",
+      "type": "category",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Coconut Rum",
+      "type": "category",
+      "quantity": {
+        "amount": 1,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "xanthan gum",
+      "type": "emulsifier",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "tsp"
+      }
+    }
+  ],
+  "instructions": ["Coat the glass with chocolate syrup."],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "qJHm91kLg3c"
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/make-and-drink/feelings-catcher.json
+++ b/packages/data/data/recipes/youtube-channel/make-and-drink/feelings-catcher.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "Feelings Catcher",
+  "preparation": "shaken",
+  "served_on": "up",
+  "glassware": "coupe",
+  "ingredients": [
+    {
+      "name": "Peychaud's bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 5,
+        "maximum": 6,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Cinnamon syrup",
+      "type": "syrup",
+      "quantity": {
+        "amount": 0.25,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lemon juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Grapefruit juice",
+      "type": "juice",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Guava syrup",
+      "type": "syrup",
+      "brix": 50,
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Coruba",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.5,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Lustau Solera Reserva Brandy de Jerez",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Elijah Craig bourbon",
+      "type": "spirit",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    }
+  ],
+  "attributions": [
+    {
+      "relation": "recipe author",
+      "source": "Ivy Mix"
+    },
+    {
+      "relation": "book",
+      "source": "Spirits of Latin America"
+    }
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "4NrM7lYTeh4"
+    }
+  ]
+}

--- a/packages/data/data/recipes/youtube-channel/truffles-on-the-rocks/pendulum.json
+++ b/packages/data/data/recipes/youtube-channel/truffles-on-the-rocks/pendulum.json
@@ -1,15 +1,23 @@
 {
   "$schema": "../../../../schemas/recipe.schema.json",
-  "name": "Gun Metal Blue",
+  "name": "Pendulum",
   "preparation": "shaken",
   "served_on": "up",
   "glassware": "coupe",
   "ingredients": [
     {
-      "name": "Cinnamon syrup",
+      "name": "Peychaud's bitters",
+      "type": "bitter",
+      "quantity": {
+        "amount": 3,
+        "unit": "dash"
+      }
+    },
+    {
+      "name": "Jasmine tea syrup",
       "type": "syrup",
       "quantity": {
-        "amount": 0.25,
+        "amount": 0.5,
         "unit": "oz"
       }
     },
@@ -17,20 +25,12 @@
       "name": "Lime juice",
       "type": "juice",
       "quantity": {
-        "amount": 0.75,
+        "amount": 1,
         "unit": "oz"
       }
     },
     {
-      "name": "Peach liqueur",
-      "type": "category",
-      "quantity": {
-        "amount": 0.25,
-        "unit": "oz"
-      }
-    },
-    {
-      "name": "Blue Curaçao",
+      "name": "Apricot liqueur",
       "type": "category",
       "quantity": {
         "amount": 0.5,
@@ -41,24 +41,21 @@
       "name": "Mezcal",
       "type": "category",
       "quantity": {
-        "amount": 1.5,
+        "amount": 2,
         "unit": "oz"
       }
     }
   ],
-  "instructions": ["Garnish with an orange coin twist and float"],
+  "attributions": [
+    {
+      "relation": "adapted by",
+      "source": "Truffles On The Rocks"
+    }
+  ],
   "refs": [
     {
       "type": "youtube",
-      "videoId": "NIZEI5gxH1o"
-    },
-    {
-      "type": "youtube",
-      "videoId": "Bk6MjJcGIaI"
-    },
-    {
-      "type": "youtube",
-      "videoId": "amV7m3Ycml8"
+      "videoId": "4y9LXFJQgBg"
     }
   ]
 }

--- a/packages/data/data/recipes/youtube-channel/truffles-on-the-rocks/white-coffee-negroni.json
+++ b/packages/data/data/recipes/youtube-channel/truffles-on-the-rocks/white-coffee-negroni.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "../../../../schemas/recipe.schema.json",
+  "name": "White Coffee Negroni",
+  "preparation": "stirred",
+  "served_on": "big rock",
+  "glassware": "old fashioned",
+  "ingredients": [
+    {
+      "name": "Blanc vermouth",
+      "type": "category",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Luxardo Bitter Bianco",
+      "type": "liqueur",
+      "quantity": {
+        "amount": 0.75,
+        "unit": "oz"
+      }
+    },
+    {
+      "name": "Gin",
+      "type": "category",
+      "technique": {
+        "technique": "fat-wash",
+        "fat": "coffee oil"
+      },
+      "quantity": {
+        "amount": 1.25,
+        "unit": "oz"
+      }
+    }
+  ],
+  "instructions": [
+    "Stir with ice.",
+    "Strain over a large clear ice cube.",
+    "Garnish with a white chocolate disk and three coffee beans."
+  ],
+  "refs": [
+    {
+      "type": "youtube",
+      "videoId": "5pRGj9A2TPk"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #390

## Summary
- add six distinct cocktail recipes from Make and Drink, The Educated Barfly, and Truffles On The Rocks
- add video references to six existing formula matches, avoiding duplicate recipes
- add the newly referenced canonical ingredient and category records

## Why
The weekly YouTube intake was missing this batch of recipe sources and formulas.

## Validation
- yarn check-data
- yarn lint
- yarn vitest --run