### PR TITLE
Fix the React Doctor job

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -20,8 +20,7 @@ jobs:
   react-doctor:
     runs-on: ubuntu-latest
     steps:
+      # The action fetches the PR base commit itself, so the default shallow
+      # checkout is enough. `fetch-depth: 0` spent ~11 min fetching this repo.
       - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      # v2.2.1+ uses actions/cache@v4, which still targets Node.js 20.
-      - uses: millionco/react-doctor@v2.2.0
+      - uses: millionco/react-doctor@v2.2.8


### PR DESCRIPTION
The React Doctor job failed on each pull request. It was successful only on a push to the `main` branch. This pull request corrects the job.

## The cause

The action writes a comment on the pull request. That comment gives the cause:

> React Doctor could not complete this scan.
> `react-doctor exited with status 0 before producing a JSON report.`

The action runs the CLI, sends the output to a file, and then examines that file. When the file has no JSON data, the action stops the job with an error. The comment is the same on all recent pull requests: #388, #391, #392 and #393.

The problem is in the action, not in this repository. The same command that the action runs makes correct JSON on a local machine:

```
react-doctor . --json --json-compact --blocking none --project '*' --scope full
react-doctor . --json --json-compact --blocking none --project '*' --scope changed --changed-files-from <file>
```

Both commands give a correct JSON report and status 0.

## The correction

The workflow used version v2.2.0 of the action. There are 8 more recent patch versions. This pull request uses v2.2.8.

The comment in the workflow is also not correct now. It said that v2.2.1 and later versions use `actions/cache@v4` with Node.js 20. But v2.2.8 uses `actions/cache@v6`.

## Also: the job was too slow

The job took approximately 12 minutes. The scan needs only 15 seconds. The `actions/checkout` step used `fetch-depth: 0`, and this step took 11.5 minutes to get all the history of this repository.

The action gets the base commit of the pull request itself. Thus the default checkout is sufficient, and this pull request removes `fetch-depth: 0`.

## How to make sure that the correction is good

The CI run of this pull request is the test. If the React Doctor job is successful, the correction is good. If the job fails again, the new log will give more data.

## An alternative that is not used

The `oxlint-plugin-react-doctor` package can run the same rules in oxlint, which this repository now uses. A test shows that the plugin finds the same problems as the CLI, and it needs only 200 ms.

But oxlint has no category or preset for the rules of a JS plugin. Thus you must write each rule in `.oxlintrc.json`, and there are 716 applicable rules. This is not practical now. It is a good option when oxlint gives support to presets for JS plugins.

## Note: the scan finds 5 problems

The full scan gives a score of 76 of 100 with these problems:

- `no-unguarded-browser-global-in-render-or-hook-init` in `hooks/useLocalStorage.ts` (error)
- `js-set-map-lookups` in `app/category/[slug]/CategoryClient.tsx` (warning)
- `no-array-index-as-key` in `app/ingredient/[type]/[slug]/IngredientClient.tsx` (warning)
- `nextjs-no-client-side-redirect` in `app/search/SearchRedirect.tsx` (warning)

This pull request does not correct these problems. The job has `blocking: none`, thus these problems do not stop the job.

[Warp conversation](https://app.warp.dev/conversation/6ea9cbe9-7cba-4fd3-9c22-481f38859f4c)

Co-Authored-By: Oz <oz-agent@warp.dev>
